### PR TITLE
Update robust-smart-contracts-with-openzeppelin.md

### DIFF
--- a/public/tutorials/robust-smart-contracts-with-openzeppelin.md
+++ b/public/tutorials/robust-smart-contracts-with-openzeppelin.md
@@ -79,7 +79,7 @@ With our front-end taken care of, we can focus on the `TutorialToken` contract.
    ```javascript
    string public name = 'TutorialToken';
    string public symbol = 'TT';
-   uint public decimals = 2;
+   uint8 public decimals = 2;
    uint public INITIAL_SUPPLY = 12000;
    ```
 


### PR DESCRIPTION
Type declaration for `decimals` property should be `uint8` instead of `uint` according to [spec](https://github.com/frozeman/EIPs/blob/94bc4311e889c2c58c561c074be1483f48ac9374/EIPS/eip-20-token-standard.md#decimals).