### PR TITLE
Minor text fix in cli tutorial

### DIFF
--- a/public/tutorials/creating-a-cli-with-truffle-3.md
+++ b/public/tutorials/creating-a-cli-with-truffle-3.md
@@ -146,7 +146,7 @@ if (command === 'bid') {
 
 ## Usage
 
-You can use the line command tool against any network that has an ENS registrar deployed. First, choose a command:
+You can use the command line tool against any network that has an ENS registrar deployed. First, choose a command:
 
 ```shell
 $ npm run -s ens


### PR DESCRIPTION
Changed `line command tool` to `command line tool` in one place.