### PR TITLE
Updating frontend/webpack tutorial to be compatible with Truffle 4

### DIFF
--- a/public/tutorials/building-testing-frontend-app-truffle-3.md
+++ b/public/tutorials/building-testing-frontend-app-truffle-3.md
@@ -46,6 +46,12 @@ networks: {
 }
 ```
 
+This is the default setting for [Ganache](/docs/ganache/using), though you can change this to use any connection you'd like.
+
+<p class="alert alert-info">
+**Note**: Read more about [setting up Ganache](/docs/ganache/using). You can also use [Truffle Develop](/docs/getting_started/console), which launches a personal blockchain for testing and is built directly into Truffle, no separate installation required.
+</p>
+
 Let's get the contracts on the network:
 
 First run `truffle compile`. This will compile the `.sol` contracts into `.json` artifacts (specified in the [`truffle-contract`](https://github.com/trufflesuite/truffle-contract) library). They will appear in `build/contracts/*.json`. Now we can include contracts in our app with a simple `import` or `require` statement:
@@ -55,7 +61,7 @@ First run `truffle compile`. This will compile the `.sol` contracts into `.json`
 import metacoin_artifacts from '../../build/contracts/MetaCoin.json'
 ```
 
-Next run `truffle migrate`. This will deploy the contracts onto the default network running at `127.0.0.1:7545`. This is the default setting for [Ganache](/docs/ganache/using), though you can change this to use any connection you'd like. 
+Next, make sure you have a blockchain running, and then run `truffle migrate`. This will deploy the contracts onto the default network running at `127.0.0.1:7545`.
 
 ### ... (webpack) build
 

--- a/public/tutorials/building-testing-frontend-app-truffle-3.md
+++ b/public/tutorials/building-testing-frontend-app-truffle-3.md
@@ -1,55 +1,67 @@
-# Building & Testing a Frontend App with Truffle 3.0
-[Truffle 3](https://github.com/ConsenSys/truffle/releases/tag/v3.0.2) is out and switched to less opinionated build process that allows any build pipeline to be plugged in. We're going to take advantage of that feature today, and build a frontend app with a custom pipeline.
+# Building and testing a frontend app with Truffle
 
-## Intended Audience
-This is written for those familiar with Truffle and Ethereum, who want a sense of how to structure a frontend application for easy development and testing. This example uses webpack, but familiarity with other build tools is enough background.
+<p class="alert alert-info">
+**Update**: While this tutorial was originally written for Truffle 3, we have updated it to be fully compatible with newer versions of Truffle. We have kept some of the language unaltered, except where necessary. 
+</p>
 
-## What does a build process need to do in Truffle 3?
-In general, simple: Turn all higher level code (like ES6, SASS, JSX, templates, etc.) into vanilla Javascript/HTML/CSS artifacts, and then move those artifacts into the `build` folder alongside our contract artifacts.
+Truffle 3 is out and switched to less opinionated build process that allows any build pipeline to be plugged in. We're going to take advantage of that feature today, and build a frontend app with a custom pipeline.
+
+## Intended audience
+
+This is written for those familiar with Truffle and Ethereum, who want a sense of how to structure a frontend application for easy development and testing. This example uses [webpack](https://webpack.js.org/), but familiarity with other build tools is enough background.
+
+## What does a build process need to do in Truffle?
+
+In general, simple: Turn all higher level code (like ES6, SASS, JSX, templates, etc.) into vanilla JavaScript/HTML/CSS artifacts, and then move those artifacts into the `build/` folder alongside our contract artifacts.
 
 ## What this tutorial does
-Uses webpack to compile the application's frontend code and move the artifacts into the `build` folder.
 
-### Getting Started
-If you were using Truffle beta 3.0.0-9 or below, **do not immediately upgrade**. Read [these release notes](https://github.com/ConsenSys/truffle/releases/tag/v3.0.2) and the [upgrade guide](http://truffleframework.com/tutorials/upgrading-from-truffle-2-to-3) first.
+Uses [webpack](https://webpack.js.org/) to compile the application's frontend code and move the artifacts into the `build/` folder.
 
-Once you have Truffle 3 installed, run `truffle init webpack` in an **empty** directory to pull down the webpack example for this tutorial [(repository here)](https://github.com/trufflesuite/truffle-init-webpack). If you're coming from Truffle 2, you'll notice your old friends `Metacoin.sol` and `ConvertLib.sol` are still there. But now, running `truffle build` does this:
-```bash
-root@b1c71a2e1a6e:/app# truffle build
+## Getting started
+
+Once you have Truffle installed, run `truffle unbox webpack` in an **empty** directory to pull down the [Truffle Box for this tutorial](/boxes/webpack) for this tutorial. If you're familiar with the [MetaCoin Truffle Box](/boxes/metacoin)), you'll notice your old friends `Metacoin.sol` and `ConvertLib.sol` are there. But now, running `truffle build` does this:
+
+```shell
 Error building:
 
-No build configuration specified. Cant build.
+No build configuration specified. Can't build.
 
 Build failed. See above.
 ```
-That's ok! Truffle 3 is getting out of your way and letting you control the build process. Our new process is specified in `webpack.config.js`. More on this later.
 
-### Compile, migrate, and ...
+That's ok! Truffle is getting out of your way and letting you control the build process. Our new process is specified in `webpack.config.js`. More on this later.
+
+## Compile, migrate, and ...
+
 In order to interact with contracts, we need them deployed on a network! The default network is configured in `truffle.js`:
-```json
-...
+
+```javascript
 networks: {
   development: {
     host: '127.0.0.1',
-    port: 8545,
+    port: 7545,
     network_id: '*' // Match any network id
   }
 }
-...
 ```
+
 Let's get the contracts on the network:
 
 First run `truffle compile`. This will compile the `.sol` contracts into `.json` artifacts (specified in the [`truffle-contract`](https://github.com/trufflesuite/truffle-contract) library). They will appear in `build/contracts/*.json`. Now we can include contracts in our app with a simple `import` or `require` statement:
+
 ```javascript
 // Import our contract artifacts and turn them into usable abstractions.
 import metacoin_artifacts from '../../build/contracts/MetaCoin.json'
 ```
 
-Next run `truffle migrate`. This will deploy the contracts onto the default network running at `127.0.0.1:8545`.
+Next run `truffle migrate`. This will deploy the contracts onto the default network running at `127.0.0.1:7545`. This is the default setting for [Ganache](/docs/ganache/using), though you can change this to use any connection you'd like. 
 
 ### ... (webpack) build
-All that's left is to use webpack to compile the app and place it in the `build/` folder. A simple `npm run build` and we're done!. Relevant configs here:
-```json
+
+All that's left is to use webpack to compile the app and place it in the `build/` folder. A simple `npm run dev` and we're done! This will build the app and serve it on `http://127.0.0.1:8080`. Relevant configs here:
+
+```javascript
 // file: package.json
 ...
   "scripts": {
@@ -59,7 +71,8 @@ All that's left is to use webpack to compile the app and place it in the `build/
   },
 ...
 ```
-```json
+
+```javascript
 // file: webpack.config.js
 ...
 entry: './app/javascripts/app.js',
@@ -75,14 +88,17 @@ plugins: [
 ],
 ...
 ```
-You can find more information on webpack concepts on [Webpack's website](https://webpack.js.org/concepts/). Notice we didn't *have* to use webpack here. But Truffle comes with a handy webpack demo that gets us started quickly. We _could_ replace the webpack config with a `Gruntfile`, for instance, and use Grunt instead. Truffle 3 don't care no mo'.
 
-## The App
-After building, run `truffle serve` which will serve the `build/` folder's contents on `127.0.0.1:8080`. To see it, navigate to [127.0.0.1:8080/index.html](127.0.0.1:8080/index.html). You should see:
+You can find more information on webpack concepts on [webpack's website](https://webpack.js.org/concepts/). Notice we didn't *have* to use webpack here, but Truffle comes with a handy webpack demo that gets us started quickly. We _could_ replace the webpack config with a `Gruntfile`, for instance, and use Grunt instead. Truffle don't care no mo'.
+
+## The app
+
+As previously mentioned, the command `npm run dev` builds the app and serves it with a local web server. (This is equivalent to running `npm run build` and then `truffle serve`, but we've done it in one step for convenience.) To see it, navigate to [http://127.0.0.1:8080](http://127.0.0.1:8080). You should see:
 
 ![](/tutorials/images/MetaCoin_running.png)
 
 That's it, all done! Happy Truffling!
 
 ## Extra: Webpack + Docker + Travis CI
+
 If you want to see how to deploy a frontend app using Docker and Travis build pipeline, check out [my frontend example](https://github.com/dougvk/truffle3-frontend-example) for added goodness.


### PR DESCRIPTION
This one now has been tested against Truffle 4, with some messaging added to reflect what's changed (example: `truffle.js` [has been updated](https://github.com/truffle-box/webpack-box/commit/7c11b9355fe08527c081346e6f1e9068ac97fec7) to point to Ganache).

I also changed the commands at the end as a workaround to https://github.com/trufflesuite/truffle/issues/448, which I found via https://github.com/trufflesuite/truffle/issues/463, which happened precisely because of this tutorial. (We should still fix the underlying issue, but that's separate from this.)

