### PR TITLE
Update using-infura-custom-provider.md

### DIFF
--- a/public/tutorials/using-infura-custom-provider.md
+++ b/public/tutorials/using-infura-custom-provider.md
@@ -56,9 +56,7 @@ The next step is to edit your `truffle.js` file to use `HDWalletProvider` and pr
    module.exports = {
      networks: {
        ropsten: {
-         provider: function() {
-           return new HDWalletProvider(mnemonic, "https://ropsten.infura.io/<INFURA_Access_Token>")
-         },
+         provider: new HDWalletProvider(mnemonic, "https://ropsten.infura.io/<INFURA_Access_Token>"),
          network_id: 3
        }   
      }


### PR DESCRIPTION
According to https://github.com/trufflesuite/truffle-hdwallet-provider, I change the provider's value from a function to a object.
It fixes "TypeError: this.provider.sendAsync is not a function" for me.