### PR TITLE
Update javascript contract testing documentations to use async await …

### DIFF
--- a/public/docs/getting_started/javascript-tests.md
+++ b/public/docs/getting_started/javascript-tests.md
@@ -35,50 +35,49 @@ File: `./test/metacoin.js`
 
 ```javascript
 // Specifically request an abstraction for MetaCoin
-var MetaCoin = artifacts.require("MetaCoin");
+const MetaCoin = artifacts.require('MetaCoin');
 
-contract('MetaCoin', function(accounts) {
-  it("should put 10000 MetaCoin in the first account", function() {
-    return MetaCoin.deployed().then(function(instance) {
-      return instance.getBalance.call(accounts[0]);
-    }).then(function(balance) {
-      assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
-    });
+before(async () => {
+  meta = await MetaCoin.deployed();
+});
+
+contract('MetaCoin', accounts => {
+  it('should put 10000 MetaCoin in the first account', async () => {
+    accOneBalance = await meta.getBalance.call(accounts[0]);
+    assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
   });
-  it("should send coin correctly", function() {
-    var meta;
-
+  it('should send coin correctly', async () => {
     // Get initial balances of first and second account.
-    var account_one = accounts[0];
-    var account_two = accounts[1];
+    const account_one = accounts[0];
+    const account_two = accounts[1];
 
-    var account_one_starting_balance;
-    var account_two_starting_balance;
-    var account_one_ending_balance;
-    var account_two_ending_balance;
+    const amount = 10;
 
-    var amount = 10;
+    const meta = await MetaCoin.deployed();
+    const balance1 = await meta.getBalance.call(account_one);
+    const balance2 = await meta.getBalance.call(account_two);
 
-    return MetaCoin.deployed().then(function(instance) {
-      meta = instance;
-      return meta.getBalance.call(account_one);
-    }).then(function(balance) {
-      account_one_starting_balance = balance.toNumber();
-      return meta.getBalance.call(account_two);
-    }).then(function(balance) {
-      account_two_starting_balance = balance.toNumber();
-      return meta.sendCoin(account_two, amount, {from: account_one});
-    }).then(function() {
-      return meta.getBalance.call(account_one);
-    }).then(function(balance) {
-      account_one_ending_balance = balance.toNumber();
-      return meta.getBalance.call(account_two);
-    }).then(function(balance) {
-      account_two_ending_balance = balance.toNumber();
+    const account_one_starting_balance = balance1.toNumber();
+    const account_two_starting_balance = balance2.toNumber();
 
-      assert.equal(account_one_ending_balance, account_one_starting_balance - amount, "Amount wasn't correctly taken from the sender");
-      assert.equal(account_two_ending_balance, account_two_starting_balance + amount, "Amount wasn't correctly sent to the receiver");
-    });
+    await meta.sendCoin(account_two, amount, { from: account_one });
+
+    const balance3 = await meta.getBalance.call(account_one);
+    const balance4 = await meta.getBalance.call(account_two);
+
+    const account_one_ending_balance = balance3.toNumber();
+    const account_two_ending_balance = balance4.toNumber();
+
+    assert.equal(
+      account_one_ending_balance,
+      account_one_starting_balance - amount,
+      "Amount wasn't correctly taken from the sender"
+    );
+    assert.equal(
+      account_two_ending_balance,
+      account_two_starting_balance + amount,
+      "Amount wasn't correctly sent to the receiver"
+    );
   });
 });
 ```


### PR DESCRIPTION
…and es6

This version uses a more condensed version that does not require a pyramid of doom using chained then()s. It should be more readable and accomplishes the same thing in fewer lines.