### PR TITLE
use contract name rather than filename for first metacoin example

### DIFF
--- a/public/docs/getting_started/javascript-tests.md
+++ b/public/docs/getting_started/javascript-tests.md
@@ -36,7 +36,7 @@ Here's an example test provided in the [MetaCoin Truffle Box](/boxes/metacoin). 
 File: `./test/metacoin.js`
 
 ```javascript
-var MetaCoin = artifacts.require("./MetaCoin.sol");
+var MetaCoin = artifacts.require("MetaCoin");
 
 contract('MetaCoin', function(accounts) {
   it("should put 10000 MetaCoin in the first account", function() {


### PR DESCRIPTION
This follows the directions in the migrations documentation to use contract names instead of filenames, since files may contain more than one contract. Referencing the filename still works in this example, but if I understand correctly, the tests could break if the user tries to create a contract abstraction by referencing a filename when the file has more than one contract.