### PR TITLE
Add hint on URL to releases page for EXE Download

### DIFF
--- a/public/ganache/index.ejs
+++ b/public/ganache/index.ejs
@@ -15,7 +15,7 @@
     </div>
 
     <div class="col-sm-4">
-      <div class="pull-right">
+      <div class="pull-right text-center">
         <a class="btn btn-orange">
           <span class="oswald">
             DOWNLOAD

--- a/public/scripts/os-detector.js
+++ b/public/scripts/os-detector.js
@@ -4,6 +4,7 @@ document.addEventListener("DOMContentLoaded", function() {
   var button = document.querySelectorAll('.btn-orange');
   var buttonImage = document.querySelectorAll('.btn-orange img');
   var buttonText = document.querySelectorAll('.btn-orange .os');
+  var allReleasesLink = document.querySelectorAll('.os-dl a');
 
   var isWindows = window.navigator.userAgent.indexOf('Windows') != -1;
   var isMac = window.navigator.userAgent.indexOf('Mac') != -1;
@@ -83,6 +84,13 @@ document.addEventListener("DOMContentLoaded", function() {
         buttonImage[i].setAttribute('src', image);
         buttonText[i].innerHTML = '(' + os + ')';
         button[i].setAttribute('href', href);
+
+        if (isWindows && supportsAppx) {
+          allReleasesLink[i].innerHTML = 'Need a different OS download (or .exe)?';
+        }
+        else {
+          allReleasesLink[i].innerHTML = 'Need a different OS download?';
+        }
       }
 
     } else {
@@ -94,6 +102,13 @@ document.addEventListener("DOMContentLoaded", function() {
         buttonImage[i].setAttribute('src', image);
         buttonText[i].innerHTML = '(' + os + ')';
         button[i].setAttribute('href', href);
+
+        if (isWindows && supportsAppx) {
+          allReleasesLink[i].innerHTML = 'Need a different OS download (or .exe)?';
+        }
+        else {
+          allReleasesLink[i].innerHTML = 'Need a different OS download?';
+        }
       }
     }
   };


### PR DESCRIPTION
In https://github.com/trufflesuite/ganache/issues/550 a user thought that we should say somewhere how to access an EXE download. This was mainly solved in #136, but this PR will let users know where to find the EXE if they want it over an AppX even though their OS supports it.