### PR TITLE
Correct quotes in import statement and string literal 

### DIFF
--- a/public/tutorials/robust-smart-contracts-with-openzeppelin.md
+++ b/public/tutorials/robust-smart-contracts-with-openzeppelin.md
@@ -62,7 +62,7 @@ With our front-end taken care of, we can focus on the `TutorialToken` contract.
    ```javascript
    pragma solidity ^0.4.17;
 
-   import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
+   import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
 
    contract TutorialToken is StandardToken {
 
@@ -77,8 +77,8 @@ With our front-end taken care of, we can focus on the `TutorialToken` contract.
 1. To set our own parameters for the token, we'll be declaring our own name, symbol, and other details. Add the following content block to the contract (between the curly braces):
 
    ```javascript
-   string public name = 'TutorialToken';
-   string public symbol = 'TT';
+   string public name = "TutorialToken";
+   string public symbol = "TT";
    uint8 public decimals = 2;
    uint public INITIAL_SUPPLY = 12000;
    ```


### PR DESCRIPTION
According to Solidity markup, literals and import statements are supposed to be in double quote. If a user is using a Solidity linter, it will give an error:

quotes: "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol": Import statements must use double quotes only.

quotes: 'TT': String literal must be quoted with double quotes.
