### PR TITLE
Remove reference to deprecated package

### DIFF
--- a/public/docs/advanced/networks.md
+++ b/public/docs/advanced/networks.md
@@ -18,7 +18,7 @@ In this example, Truffle will run your migrations on the "live" network, which -
 
 ## Build artifacts
 
-As mentioned in the [Compiling contracts](/docs/getting_started/compile) section, build artifacts are stored in the `./build/contracts` directory as `.json` files. When you compile your contracts or run your migrations using a specific network, Truffle will update those `.json` files so they contain the information related to that network. When those artifacts are used later -- such as within your frontend or application via [truffle-contract](https://github.com/trufflesuite/truffle-contract) -- they'll automatically detect which network the Ethereum client is connected to and use the correct contract artifacts accordingly.
+As mentioned in the [Compiling contracts](/docs/getting_started/compile) section, build artifacts are stored in the `./build/contracts` directory as `.json` files. When you compile your contracts or run your migrations using a specific network, Truffle will update those `.json` files so they contain the information related to that network. When those artifacts are used later -- such as within your frontend or application -- they'll automatically detect which network the Ethereum client is connected to and use the correct contract artifacts accordingly.
 
 ## Application deployment
 


### PR DESCRIPTION
It'd probably be better to refer to the correct command or module, but this is better than referring to a deprecated repo.