### PR TITLE
Correcting typo in using-an-existing-redux-store.md

### DIFF
--- a/src/docs/drizzle/getting-started/using-an-existing-redux-store.md
+++ b/src/docs/drizzle/getting-started/using-an-existing-redux-store.md
@@ -36,7 +36,7 @@ export default function* root() {
 }
 ```
 
-Now we can use the reducers and sagas as we normally would in our store. Note that we must also generate an initial state for our contracts. Drizzle takes care of this for you with the `` function.
+Now we can use the reducers and sagas as we normally would in our store. Note that we must also generate an initial state for our contracts. Drizzle takes care of this for you with the `generateContractsInitialState` function.
 
 ```javascript
 // ...


### PR DESCRIPTION
Currently a typo in the instructions, where the a specific function is supposed to be referenced but only an empty set of quotes appears. Pretty confusing. This fixes that so the function you're referencing now appears.