### PR TITLE
Make some visual changes to the TruffleCon page to priortize people's attention.

### DIFF
--- a/src/trufflecon2018.html
+++ b/src/trufflecon2018.html
@@ -15,17 +15,18 @@ layout: layout.hbs
       </div>
     </div>
 
-    <div class="row mt-5 align-items-center justify-content-md-center">
-      <div class="col-xs-12 col-sm-6 col-md-6 col-lg-3 mb-3 mb-sm-0 text-center">
-        <h5>Attend TruffleCon 2018</h5>
-        <a href="https://trufflecon2018.eventbrite.com/" class="btn btn-block btn-eventbrite">BUY TICKETS</a>
-        <a href="https://goo.gl/forms/wNvTbdOZz8Yn5qHz1" class="btn btn-block btn-truffle">VOLUNTEER</a>
+    <div class="row mt-5 align-items-center justify-content-center">
+      <div class="col-xs-12 col-sm-6 col-md-6 col-lg-4 mb-1 mb-sm-0 text-center">
+        <a href="https://trufflecon2018.eventbrite.com/" class="btn btn-block btn-eventbrite w-100 mw-100">BUY TICKETS</a>
       </div>
+    </div>
 
-      <div class="col-xs-12 col-sm-6 col-md-6 col-lg-3 text-center">
-        <h5>Sponsor TruffleCon 2018</h5>
-        <a href="https://truffleframework.com/files/TruffleCon2018SponsorshipProspectus.pdf" class="btn btn-block btn-truffle">SPONSORSHIP PROSPECTUS</a>
-        <a href="mailto:trufflecon@trufflesuite.com" class="btn btn-block btn-truffle">BECOME A SPONSOR</a>
+    <div class="row mt-3 align-items-center justify-content-center">
+      <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2 mb-3 mb-sm-0 text-center">
+        <a href="https://goo.gl/forms/wNvTbdOZz8Yn5qHz1" class="btn btn-block btn-truffle w-100 mw-100">Volunteer</a>
+      </div>
+      <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2 mb-3 mb-sm-0 text-center">
+        <a href="https://truffleframework.com/files/TruffleCon2018SponsorshipProspectus.pdf" class="btn btn-block btn-truffle w-100 mw-100">Become a Sponsor</a>
       </div>
     </div>
 
@@ -58,17 +59,7 @@ layout: layout.hbs
     <div class="row">
       <div class="col">
         <p>Join people from around the world as we meet to build community and foster connections in the Ethereum developer space; share tips and tricks, challenges and successes.</p>
-        <p>Our goal is to inspire you to build your dapps and smart contracts to bring your ideas to the world! And we'll have some fun too while we're at it. And maybe chocolate too.</p>
         
-        <h1 class="link-markdown mb-4 mt-4"><a href="#plan-your-time" name="plan-your-time"><i class="fas fa-link"></i></a>PLAN YOUR TIME</h1>
-        <p>
-          <strong>Friday, October 5</strong>: Hands-on workshops (bring your laptop!)<br/>
-          <strong>Saturday, October 6</strong>: Main event + breakout sessions<br/>
-          <strong>Sunday, October 7</strong>: Breakout sessions + unconference
-        </p>
-        <p>More detailed schedule, including social events, coming soon!</p>
-        <p><em>(Note: The workshops on Friday, October 5 are capacity controlled and are covered under a separate ticket. <strong>If you wish to reserve a space for yourself in the workshops, please purchase the "Workshop add-on" ticket as well.</strong> The sign up process for specific workshops will happen at a later time.)</em></p>
-      
         <h1 class="link-markdown mb-4 mt-4"><a href="#speakers" name="speakers"><i class="fas fa-link"></i></a>SPEAKERS</h1>
       </div>
     </div>
@@ -188,8 +179,21 @@ layout: layout.hbs
       <div class="col">
         <h1 class="link-markdown mb-4 mt-4"><a href="#location" name="location"><i class="fas fa-link"></i></a>LOCATION</h1>
         <p>TruffleCon 2018 will be at the <a href="http://portland.hilton.com/">Hilton Portland Downtown</a> hotel, right in the heart of downtown Portland, Oregon. Easily accessible from the airport and steps from many of Portland's most famous landmarks and dozens of food carts, the Hilton provides an excellent backdrop for TruffleCon 2018.</p>
+
+        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2795.6222822464706!2d-122.68155083376658!3d45.51768173789306!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54950a0516efe13b%3A0x4806192199eb9892!2sHilton+Portland+Downtown!5e0!3m2!1sen!2sus!4v1534441385850" class="w-100 mb-1" height="200" frameborder="0" style="border:0" allowfullscreen></iframe>
+
         <p>We have negotiated a special rate for TruffleCon attendees. <strong>Use the Group Code: CON</strong> (not Promotion/Offer Code!) <strong>when booking to receive your special rate.</strong> These rooms are limited, so please don't delay. <strong>You must book by September 6, 2018.</strong></p>
         <p>Workshops on October 5 will be at a different location, the <a href="https://www.pcc.edu/climb/">PCC CLIMB Center</a>, a short distance away from the Hilton.</p>
+
+        <h1 class="link-markdown mb-4 mt-4"><a href="#plan-your-time" name="plan-your-time"><i class="fas fa-link"></i></a>SCHEDULE</h1>
+        <p>
+          <strong>Friday, October 5</strong>: Hands-on workshops (bring your laptop!)<br/>
+          <strong>Saturday, October 6</strong>: Main event + breakout sessions<br/>
+          <strong>Sunday, October 7</strong>: Breakout sessions + unconference
+        </p>
+        <p>More detailed schedule, including social events, coming soon!</p>
+        <p><em>(Note: The workshops on Friday, October 5 are capacity controlled and are covered under a separate ticket. <strong>If you wish to reserve a space for yourself in the workshops, please purchase the "Workshop add-on" ticket as well.</strong> The sign up process for specific workshops will happen at a later time.)</em></p>
+      
 
         <h1 class="link-markdown mb-4 mt-4"><a href="#faq" name="faq"><i class="fas fa-link"></i></a>FAQ</h1>
         <ul class="faq">


### PR DESCRIPTION
* Prioritized calls to action in the header, with Buy Tickets as the most important.
* Removed "Sponsorship Prospectus" call to action, and kept "Become a Sponsor". *However:* "Become a Sponsor" now links to the prospectus instead of the email. There's way more information in the prospectus, and there's email addresses sponsor's can use as next steps.
* Added a google maps embed for the location.
* Changed "Plan Your Time" to "Schedule"
* Moved "Schedule" section below "Location", so that Speakers is up top and potentially above the fold.