### PR TITLE
Fix non-master builds by adding conditional statement to travis script 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,15 @@ before_script:
    fi
 
 script:
-- mv build/.git .git-backup
-- npm run build
-- mv .git-backup build/.git
+- >
+  if [ "${TRAVIS_PULL_REQUEST}" = "false" -a "$TRAVIS_BRANCH" = "${MASTER}" ];
+  then
+    mv build/.git .git-backup
+    npm run build
+    mv .git-backup build/.git
+  else
+    npm run build
+  fi
 
 after_success:
 - >


### PR DESCRIPTION
Builds are failing on non-master branches.

# Problem

It seems to be caused by the `script:` section in `.travis.yml`.

When the branch is `master`, the `before_script:` runs `git clone "${GH_REF}" build` which creates a git project inside the `build` directory. In order to preserve the `.git` history inside this build folder, the `script:` script moves the `build/.git` directory to `.git-backup`.

However, when the branch is non-`master`, this cloning doesn't happen. And as a result, the `build/.git` folder doesn't exist and an error is thrown.

# Solution

Wrap the `mv` commands under an if/else block. See diff for more info.