### PR TITLE
Update writing-tests-in-solidity.md

### DIFF
--- a/src/docs/truffle/testing/writing-tests-in-solidity.md
+++ b/src/docs/truffle/testing/writing-tests-in-solidity.md
@@ -61,7 +61,7 @@ To better understand whats happening, let's discuss things in more detail.
 
 ### Assertions
 
-Your assertion functions like `Assert.equal()` are provided to you by the `truffle/Assert.sol` library. This is the default assertion library, however you can include your own assertion library so long as the library loosely integrates with Truffle's test runner by triggering the correct assertion events. You can find all available assertion functions in [Assert.sol](https://github.com/ConsenSys/truffle/blob/beta/lib/testing/Assert.sol).
+Your assertion functions like `Assert.equal()` are provided to you by the `truffle/Assert.sol` library. This is the default assertion library, however you can include your own assertion library so long as the library loosely integrates with Truffle's test runner by triggering the correct assertion events. You can find all available assertion functions in [Assert.sol](https://github.com/trufflesuite/truffle/blob/develop/packages/truffle-core/lib/testing/Assert.sol).
 
 ### Deployed addresses
 


### PR DESCRIPTION
Old link was a 404. This update corrects a link so it navigates the user to the correct truffle core package.