### PR TITLE
Fix initial migration filename

### DIFF
--- a/src/docs/truffle/quickstart.md
+++ b/src/docs/truffle/quickstart.md
@@ -65,7 +65,7 @@ Once this operation is completed, you'll now have a project structure with the f
 
 1. Open the `contracts/Migrations.sol` file. This is a separate Solidity file that manages and updates [the status of your deployed smart contract](/docs/truffle/getting-started/running-migrations). This file comes with every Truffle project, and is usually not edited. 
 
-1. Open the `migrations/1_initial_deployment.js` file. This file is the migration (deployment) script for the `Migrations` contract found in the `Migrations.sol` file.
+1. Open the `migrations/1_initial_migration.js` file. This file is the migration (deployment) script for the `Migrations` contract found in the `Migrations.sol` file.
 
 1. Open the `migrations/2_deploy_contracts.js` file. This file is the migration script for the `MetaCoin` contract. (Migration scripts are run in order, so the file beginning with `2` will be run after the file beginning with `1`.)
 


### PR DESCRIPTION
I suppose it used to be `1_initial_deployment.js` but now it's `1_initial_migration.js` and there are other parts in this doc where it was updated. Probably just missed this one.