### PR TITLE
Create an even quicker start for the built-in VM

### DIFF
--- a/src/docs/truffle/quickerstart.md
+++ b/src/docs/truffle/quickerstart.md
@@ -5,7 +5,7 @@ layout: docs.hbs
 # Truffle Quickerstart
 
 This page will take you very briefly through the basics of creating a Truffle project and 
-debugging it on a local blockchain.  For more details and alternative blockchains, see 
+debugging a test execution on Truffle’s built-in blockchain.  For more details, debugging migrations, and alternative blockchains, see 
 the [Quickstart](/docs/truffle/quickstart)
 
 ## Creating a project
@@ -60,6 +60,6 @@ Search for “Transaction:”; copy the long hex number after the colon.
    debug 0xf6867abd2f69584671b39338387293bfc1983c37177a13f14254ab19b42972da
    ```
    
-1. Use the usual command-line debugger commands (o, i, u, n, ;, q etc.) to step through 
+1. Use command-line debugger commands (o, i, u, n, ;, q etc.) to step through 
    source; see [Debugging Your Contracts](/docs/truffle/getting-started/debugging-your-contracts) 
    for details.

--- a/src/docs/truffle/quickerstart.md
+++ b/src/docs/truffle/quickerstart.md
@@ -1,0 +1,65 @@
+---
+title: Truffle | Truffle Quickerstart
+layout: docs.hbs
+---
+# Truffle Quickerstart
+
+This page will take you very briefly through the basics of creating a Truffle project and 
+debugging it on a local blockchain.  For more details and alternative blockchains, see 
+the [Quickstart](/docs/truffle/quickstart)
+
+## Creating a project
+
+To use most Truffle commands, you need to run them against an existing Truffle project. 
+So the first step is to create a Truffle project.
+
+We'll use the [MetaCoin box](/boxes/metacoin), which creates a token that can be transferred 
+between accounts:
+
+1. Create a new directory for your Truffle project:
+
+   ```shell
+   mkdir MetaCoin
+   cd MetaCoin
+   ```
+
+1. Download ("unbox") the MetaCoin box:
+
+   ```shell
+   truffle unbox metacoin
+   ```
+   
+1. In a second terminal window in the same directory, turn on logging:
+
+   ```shell
+   truffle develop --log
+   ```
+
+## Testing
+
+1. In your main terminal window, enter Truffle Develop:
+
+   ```shell
+   truffle develop
+   ```
+
+1. Run the Solidity test:
+
+   ```shell
+   test
+   ```
+
+## Debugging
+
+1. Find a transaction ID in the log window for a transaction you’re interested in.  
+Search for “Transaction:”; copy the long hex number after the colon.
+1. In the main terminal window, type “debug ” and paste the ID, e.g. 
+(your ID will be different):
+
+   ```shell
+   debug 0xf6867abd2f69584671b39338387293bfc1983c37177a13f14254ab19b42972da
+   ```
+   
+1. Use the usual command-line debugger commands (o, i, u, n, ;, q etc.) to step through 
+   source; see [Debugging Your Contracts](/docs/truffle/getting-started/debugging-your-contracts) 
+   for details.

--- a/src/docs/truffle/quickerstart.md
+++ b/src/docs/truffle/quickerstart.md
@@ -60,6 +60,6 @@ Search for “Transaction:”; copy the long hex number after the colon.
    debug 0xf6867abd2f69584671b39338387293bfc1983c37177a13f14254ab19b42972da
    ```
    
-1. Use command-line debugger commands (o, i, u, n, ;, q etc.) to step through 
+1. Use command-line debugger commands (`o`, `i`, `u`, `n`, `;`, `q`, etc.) to step through 
    source; see [Debugging Your Contracts](/docs/truffle/getting-started/debugging-your-contracts) 
    for details.


### PR DESCRIPTION
Create an even quicker start for debugging a test on the built-in VM, which avoids much of the complexity and discussion of alternate VMs in the quick start, and mentions a crucial step for tests on the built-in VM.  Setting up debugging was even easier than the existing Quick Start made it seem, and the discussion of alternate VMs led me through a long detour.
