### PR TITLE
Fixed params in contract adding method

### DIFF
--- a/src/docs/drizzle/getting-started/contract-interaction.md
+++ b/src/docs/drizzle/getting-started/contract-interaction.md
@@ -81,5 +81,5 @@ events = ['Mint']
 dispatch({type: 'ADD_CONTRACT', drizzle, contractConfig, events, web3})
 
 // Or using the Drizzle context object
-this.context.drizzle.addContract({contractConfig, events})
+this.context.drizzle.addContract(contractConfig, events)
 ```


### PR DESCRIPTION
Currently it is unclear if I should be passing object containing specified properties, but actually user should be sending two values as arguments (contract config and events array)

Related to https://github.com/trufflesuite/drizzle/pull/114