### PR TITLE
Fix links to be correct as to each truffle package

### DIFF
--- a/src/blog/announcing-full-portable-solidity-debugger.md
+++ b/src/blog/announcing-full-portable-solidity-debugger.md
@@ -2,7 +2,7 @@ Every one at Truffle is giddy right now.
 
 ----------------
 
-Since Truffle's inception, it's been our mission to build outstanding development tools for the Ethereum community. The analogy we always used was one of history: Ethereum development practices are years behind the rest of the industry, and it's our job to build tools that modernize our craft. Well today, Truffle's come one step closer to that goal. We're happy to announce the release of our fully featured, fully portable Solidity [debugger](https://github.com/trufflesuite/truffle/releases) and [debugging libraries](https://github.com/trufflesuite/truffle-debugger/). 
+Since Truffle's inception, it's been our mission to build outstanding development tools for the Ethereum community. The analogy we always used was one of history: Ethereum development practices are years behind the rest of the industry, and it's our job to build tools that modernize our craft. Well today, Truffle's come one step closer to that goal. We're happy to announce the release of our fully featured, fully portable Solidity [debugger](https://github.com/trufflesuite/truffle/releases) and [debugging libraries](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-debugger).
 
 ![Debugger in Action](https://i.imgur.com/7y80aF3.gif)
 
@@ -70,7 +70,7 @@ More information about how to use Truffle can be found in [our documentation](/d
 
 ### A Quick Thank You
 
-I'd like to personally thank the whole Truffle team for this effort, and particularly [Nick D'Andrea](https://github.com/gnidan) for turning some initial research work into a fully portable, fully featured debugger. The engineering under the hood is amazing, [I urge you to take a look](https://github.com/trufflesuite/truffle-debugger/). I'd also like to thank the community at large: It's a pleasure building the tools that make your lives easier, and your consistent feedback makes the whole endeavor worthwhile.
+I'd like to personally thank the whole Truffle team for this effort, and particularly [Nick D'Andrea](https://github.com/gnidan) for turning some initial research work into a fully portable, fully featured debugger. The engineering under the hood is amazing, [I urge you to take a look](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-debugger). I'd also like to thank the community at large: It's a pleasure building the tools that make your lives easier, and your consistent feedback makes the whole endeavor worthwhile.
 
 Thanks,
 <br/>-- Tim 

--- a/src/docs/truffle/advanced/build-processes.md
+++ b/src/docs/truffle/advanced/build-processes.md
@@ -62,7 +62,7 @@ When configuring your build tool or application, you'll need to perform the foll
 
 1) Get all your contract artifacts into your build pipeline / application. This includes all of the `.json` files within the `./build/contracts` directory.
 
-2) Turn those `.json` contract artifacts into contract abstractions that are easy to use, via [truffle-contract](https://github.com/trufflesuite/truffle-contract).
+2) Turn those `.json` contract artifacts into contract abstractions that are easy to use, via [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract).
 
 3) Provision those contract abstractions with a Web3 provider. In the browser, this provider might come from [Metamask](https://metamask.io/) or [Mist](https://github.com/ethereum/mist), but it could also be a custom provider you've configured to point to [Infura](http://infura.io/) or any other Ethereum client.
 

--- a/src/docs/truffle/advanced/networks-and-app-deployment.md
+++ b/src/docs/truffle/advanced/networks-and-app-deployment.md
@@ -22,7 +22,7 @@ In this example, Truffle will run your migrations on the "live" network, which -
 
 ## Build artifacts
 
-As mentioned in the [Compiling contracts](/docs/truffle/getting-started/compiling-contracts) section, build artifacts are stored in the `./build/contracts` directory as `.json` files. When you compile your contracts or run your migrations using a specific network, Truffle will update those `.json` files so they contain the information related to that network. When those artifacts are used later -- such as within your frontend or application via [truffle-contract](https://github.com/trufflesuite/truffle-contract) -- they'll automatically detect which network the Ethereum client is connected to and use the correct contract artifacts accordingly.
+As mentioned in the [Compiling contracts](/docs/truffle/getting-started/compiling-contracts) section, build artifacts are stored in the `./build/contracts` directory as `.json` files. When you compile your contracts or run your migrations using a specific network, Truffle will update those `.json` files so they contain the information related to that network. When those artifacts are used later -- such as within your frontend or application via [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) -- they'll automatically detect which network the Ethereum client is connected to and use the correct contract artifacts accordingly.
 
 ## Application deployment
 

--- a/src/docs/truffle/getting-started/interacting-with-your-contracts.md
+++ b/src/docs/truffle/getting-started/interacting-with-your-contracts.md
@@ -34,7 +34,7 @@ Choosing between a transaction and a call is as simple as deciding whether you w
 
 ## Introducing abstractions
 
-Contract abstractions are the bread and butter of interacting with Ethereum contracts from Javascript. In short, contract abstractions are wrapper code that makes interaction with your contracts easy, in a way that lets you forget about the many engines and gears executing under the hood. Truffle uses its own contract abstraction via the [truffle-contract](https://github.com/trufflesuite/truffle-contract) module, and it is this contract abstraction that's described below.
+Contract abstractions are the bread and butter of interacting with Ethereum contracts from Javascript. In short, contract abstractions are wrapper code that makes interaction with your contracts easy, in a way that lets you forget about the many engines and gears executing under the hood. Truffle uses its own contract abstraction via the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) module, and it is this contract abstraction that's described below.
 
 In order to appreciate the usefulness of a contract abstraction, however, we first need a contract to talk about. We'll use the MetaCoin contract available to you through Truffle Boxes via `truffle unbox metacoin`.
 
@@ -198,11 +198,11 @@ MetaCoin.deployed().then(function(instance) {
 
 When you make a transaction, you're given a `result` object that gives you a wealth of information about the transaction. Specifically, you get the following:
 
-* `result.tx` *(string)* - Transaction hash 
+* `result.tx` *(string)* - Transaction hash
 * `result.logs` *(array)* - Decoded events (logs)
 * `result.receipt` *(object)* - Transaction receipt
 
-For more information, please see the [README](https://github.com/trufflesuite/truffle-contract) in the `truffle-contract` project.
+For more information, please see the [README](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) in the `truffle-contract` package.
 
 ### Add a new contract to the network
 
@@ -247,4 +247,4 @@ instance.send(web3.toWei(1, "ether")).then(function(result) {
 
 ## Further reading
 
-The contract abstractions provided by Truffle contain a wealth of utilities for making interacting with your contracts easy. Check out the [truffle-contract](https://github.com/trufflesuite/truffle-contract) documentation for tips, tricks and insights.
+The contract abstractions provided by Truffle contain a wealth of utilities for making interacting with your contracts easy. Check out the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) documentation for tips, tricks and insights.

--- a/src/docs/truffle/getting-started/package-management-via-npm.md
+++ b/src/docs/truffle/getting-started/package-management-via-npm.md
@@ -44,7 +44,7 @@ Since the path didn't start with `./`, Truffle knows to look in your project's `
 
 ### Within JavaScript code
 
-To interact with package's contracts within JavaScript code, you simply need to `require` that package's `.json` files, and then use the [truffle-contract](https://github.com/trufflesuite/truffle-contract) module to turn those into usable abstractions:
+To interact with package's contracts within JavaScript code, you simply need to `require` that package's `.json` files, and then use the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) module to turn those into usable abstractions:
 
 ```
 var contract = require("truffle-contract");

--- a/src/docs/truffle/getting-started/running-migrations.md
+++ b/src/docs/truffle/getting-started/running-migrations.md
@@ -180,7 +180,7 @@ You can optionally pass an array of contracts, or an array of arrays, to speed u
 
 Note that you will need to deploy and link any libraries your contracts depend on first before calling `deploy`. See the `link` function below for more details.
 
-For more information, please see the [truffle-contract](https://github.com/trufflesuite/truffle-contract) documentation.
+For more information, please see the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) documentation.
 
 
 Examples:

--- a/src/docs/truffle/getting-started/truffle-with-metamask.md
+++ b/src/docs/truffle/getting-started/truffle-with-metamask.md
@@ -4,7 +4,7 @@ layout: docs.hbs
 ---
 # Truffle and MetaMask
 
-Before you can interact with smart contracts in a browser, make sure they're compiled, deployed, and that you're interacting with them via `web3` in client-side JavaScript. We recommend using the [truffle-contract](https://github.com/trufflesuite/truffle-contract) library, as it makes interacting with contracts easier and more robust.
+Before you can interact with smart contracts in a browser, make sure they're compiled, deployed, and that you're interacting with them via `web3` in client-side JavaScript. We recommend using the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) library, as it makes interacting with contracts easier and more robust.
 
 <p class="alert alert-info">
 <strong>Note</strong>: For more information on these topics, including using `truffle-contract`, check out our [Pet Shop](/tutorials/pet-shop) or [TutorialToken](/tutorials/robust-smart-contracts-with-openzeppelin) tutorials.

--- a/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
+++ b/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
@@ -332,7 +332,7 @@ We originally configured Truffle to point our development environment to the fir
 
 So far, we've shown you how to deploy contracts that are private within your migrations. When building a dapp on Quorum, it'd also be helpful to learn how to make *all* transactions private.
 
-Truffle uses its [truffle-contract](https://github.com/trufflesuite/truffle-contract) contract abstraction wherever contracts are used in JavaScript. When you interacted with `SimpleStorage` in the console above, for instance, you were using a `truffle-contract` contract abstraction. These abstractions are also used within your migrations, your JavaScript-based unit tests, as well as executing external scripts with Truffle.
+Truffle uses its [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) contract abstraction wherever contracts are used in JavaScript. When you interacted with `SimpleStorage` in the console above, for instance, you were using a `truffle-contract` contract abstraction. These abstractions are also used within your migrations, your JavaScript-based unit tests, as well as executing external scripts with Truffle.
 
 Truffle's contract abstraction allow you to make a transaction against any function available on the contract. It does so by evaluating the functions of the contract and making them available to JavaScript. To see these transactions in action, we're going to use an advanced feature of Truffle that lets us execute external scripts within our Truffle environment.
 

--- a/src/tutorials/building-testing-frontend-app-truffle-3.md
+++ b/src/tutorials/building-testing-frontend-app-truffle-3.md
@@ -52,7 +52,7 @@ This is the default setting for [Ganache](/docs/ganache/using), though you can c
 
 Let's get the contracts on the network:
 
-First run `truffle compile`. This will compile the `.sol` contracts into `.json` artifacts (specified in the [`truffle-contract`](https://github.com/trufflesuite/truffle-contract) library). They will appear in `build/contracts/*.json`. Now we can include contracts in our app with a simple `import` or `require` statement:
+First run `truffle compile`. This will compile the `.sol` contracts into `.json` artifacts (specified in the [`truffle-contract`](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract) library). They will appear in `build/contracts/*.json`. Now we can include contracts in our app with a simple `import` or `require` statement:
 
 ```javascript
 // Import our contract artifacts and turn them into usable abstractions.

--- a/src/tutorials/pet-shop.md
+++ b/src/tutorials/pet-shop.md
@@ -282,7 +282,7 @@ Truffle is very flexible when it comes to smart contract testing, in that tests 
 
 We start the contract off with 3 imports:
 
-* `Assert.sol`: Gives us various assertions to use in our tests. In testing, **an assertion checks for things like equality, inequality or emptiness to return a pass/fail** from our test. [Here's a full list of the assertions included with Truffle](https://github.com/trufflesuite/truffle-core/blob/master/lib/testing/Assert.sol).
+* `Assert.sol`: Gives us various assertions to use in our tests. In testing, **an assertion checks for things like equality, inequality or emptiness to return a pass/fail** from our test. [Here's a full list of the assertions included with Truffle](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-core/lib/testing/Assert.sol).
 * `DeployedAddresses.sol`: When running tests, Truffle will deploy a fresh instance of the contract being tested to the blockchain. This smart contract gets the address of the deployed contract.
 * `Adoption.sol`: The smart contract we want to test.
 

--- a/src/tutorials/upgrading-from-truffle-2-to-3.md
+++ b/src/tutorials/upgrading-from-truffle-2-to-3.md
@@ -337,7 +337,7 @@ module.exports = {
 
 You'll notice that in version 3.0 we `require`'d the default builder as a dependency and then passed that object into our configuration. Otherwise, the configuration was the same!
 
-Now, be aware that the default builder does use the latest contract abstractions ([truffle-contract](https://github.com/trufflesuite/truffle-contract)), so you will still need to edit your application to account for the breaking changes mentioned above.
+Now, be aware that the default builder does use the latest contract abstractions ([truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract)), so you will still need to edit your application to account for the breaking changes mentioned above.
 
 ### Use a custom build process / build tool
 
@@ -348,7 +348,7 @@ Whether you're building an application to run in the browser, or a command line 
 When configuring your build tool or application, you'll need to perform the following steps;
 
 1. Get all your contract artifacts into your build pipeline / application. This includes all of the `.json` files within the `./build/contracts` directory.
-2. Turn those `.json` contract artifacts into contract abstractions that are easy to use, via [truffle-contract](https://github.com/trufflesuite/truffle-contract).
+2. Turn those `.json` contract artifacts into contract abstractions that are easy to use, via [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract).
 3. Provision those contract abstractions with a Web3 provider. In the browser, this provider might come from [Metamask](https://metamask.io/) or [Mist](https://github.com/ethereum/mist), but it could also be a custom provider you've configured to point to [Infura](http://infura.io/) or any other Ethereum client.
 4. Use your contracts!
 


### PR DESCRIPTION
Previous links like `[debugging libraries](https://github.com/trufflesuite/truffle-debugger/)` were displayed as "⚠️ This repo is deprecated ⚠️" if you accessed. I fixed those links to be able to show correct package page. Thanks 👍 
