### PR TITLE
Added info to explain the view keyword

### DIFF
--- a/src/tutorials/pet-shop.md
+++ b/src/tutorials/pet-shop.md
@@ -157,8 +157,11 @@ As mentioned above, array getters return only a single value from a given key. O
      return adopters;
    }
    ```
+Things to notice:
 
-Since `adopters` is already declared, we can simply return it. Be sure to specify the return type (in this case, the type for `adopters`) as `address[16]`.
+* Since `adopters` is already declared, we can simply return it. Be sure to specify the return type (in this case, the type for `adopters`) as `address[16]`.
+
+* The `view` keyword in the function declaration means that the function will not modify the state of the contract. Further information about the exact limits imposed by view is available [here](https://solidity.readthedocs.io/en/latest/contracts.html#view-functions).
 
 
 ## Compiling and migrating the smart contract


### PR DESCRIPTION
Under the section "Your second function: Retrieving the adopters" the view keyword is used in the function declaration but no explanation or link to more info was provided. I added a blurb about it and a link to the docs.