### PR TITLE
Fix problem with markdown not displaying correctly

### DIFF
--- a/src/sass/pages/tutorials.scss
+++ b/src/sass/pages/tutorials.scss
@@ -2,7 +2,7 @@
   position: relative;
   border: none;
   margin-bottom: 2rem;
-  
+
   &::before {
     content: "";
     position: absolute;
@@ -43,4 +43,9 @@
   background: -webkit-linear-gradient(top, rgba(63,224,197,1) 0%,rgba(228,166,99,1) 50%,rgba(233,17,189,1) 100%); /* Chrome10-25,Safari5.1-6 */
   background: linear-gradient(to bottom, rgba(63,224,197,1) 0%,rgba(228,166,99,1) 50%,rgba(233,17,189,1) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#3fe0c5', endColorstr='#e911bd',GradientType=0 ); /* IE6-9 */
+}
+
+.centralized-db-image {
+  margin: 0 auto;
+  max-width: 430px;
 }

--- a/src/tutorials/ethereum-overview.md
+++ b/src/tutorials/ethereum-overview.md
@@ -31,9 +31,9 @@ Centralized systems can be manipulated, from inside or outside, so we have to tr
 
 A self-hosted blog is a common example of a centralized database. The owner could potentially edit posts in hindsight or censor users without recourse. Alternately, a hacker could infiltrate the server and commit malicious acts. If there is no database backup, reversing the damage might be impossible.
 
-{{#> breakout maxWidth=430 }}
-  ![Centralized Database](/img/tutorials/ethereum-overview/db-server.png "Graphically represented, each arrow crossing a boundary of the main server box is a connection which requires trust")
-{{/breakout}}
+<div class="centralized-db-image">
+![Centralized Database](/img/tutorials/ethereum-overview/db-server.png "Graphically represented, each arrow crossing a boundary of the main server box is a connection which requires trust")
+</div>
 
 ### The need to share data
 


### PR DESCRIPTION
The markdown below the first image was not displaying correctly and instead was being displayed as a string.

For example, <code>## The need to share data</code> instead of displaying this as a bold heading.