### PR TITLE
Added cross-link for `truffle exec` docs

### DIFF
--- a/src/docs/truffle/getting-started/writing-external-scripts.md
+++ b/src/docs/truffle/getting-started/writing-external-scripts.md
@@ -14,6 +14,8 @@ To run an external script, perform the following:
 $ truffle exec <path/to/file.js>
 ```
 
+Refer to [Truffle Commands Reference](/docs/truffle/reference/truffle-commands#exec) for more information about this command, such as what options it accepts.
+
 ## File structure
 
 In order for external scripts to be run correctly, Truffle expects them to export a function that takes a single parameter as a callback:


### PR DESCRIPTION
Makes it easier for users to jump between guides and reference docs.