### PR TITLE
Correction of web3.toWei() function - addressing deprecation

### DIFF
--- a/src/docs/truffle/getting-started/interacting-with-your-contracts.md
+++ b/src/docs/truffle/getting-started/interacting-with-your-contracts.md
@@ -213,7 +213,7 @@ instance.sendTransaction({...}).then(function(result) {
 Option 2: There's also shorthand for just sending Ether directly:
 
 ```javascript
-instance.send(web3.toWei(1, "ether")).then(function(result) {
+instance.send(web3.utils.toWei(1, "ether")).then(function(result) {
   // Same result object as above.
 });
 ```


### PR DESCRIPTION
The web3.toWei() function is deprecated as it is now stored under utils. Changed it from web3.toWei() to web3.utils.toWei()

I feel like it is important to keep these up to date as a lot of beginners will work through these docs and might pick up deprecated syntax otherwise.

Web3 Docs: https://web3js.readthedocs.io/en/1.0/web3-utils.html

All the best!