### PR TITLE
Update `timeoutBlocks` description as `keep waiting`

### DIFF
--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -82,7 +82,7 @@ networks: {
     //          - function that returns a web3 provider instance (see below.)
     //          - if specified, host and port are ignored.
     // skipDryRun: - true if you don't want to test run the migration locally before the actual migration (default is false)
-    // timeoutBlocks: - if a transaction is not mined, keep retrying for this number of blocks (default is 50)
+    // timeoutBlocks: - if a transaction is not mined, keep waiting for this number of blocks (default is 50)
   }
 }
 ```


### PR DESCRIPTION
Original comment
```
// timeoutBlocks: - if a transaction is not mined, keep retrying for this number of blocks (default is 50)
```
The word `retrying` is a bit misleading. As a developer might think that the Truffle will re-initiate the transaction.