### PR TITLE
Add instructions for deploying using private key instead of mnemonic

### DIFF
--- a/src/tutorials/using-infura-custom-provider.md
+++ b/src/tutorials/using-infura-custom-provider.md
@@ -158,3 +158,7 @@ We are now ready to deploy to Ropsten!
    You should see details about the transaction, including the block number where the transaction was secured.
 
 Congratulations! You've deployed your contract to Ropsten using the combined power of Infura and Truffle.
+
+## Using a Private Key Instead of a Mnemonic
+
+If you have a private key instead of a mnemonic (i.e. your MetaMask account), you can follow a very similar procedure to this by using [this package](https://github.com/rhlsthrm/truffle-hdwallet-provider-privkey) instead.


### PR DESCRIPTION
I created a package (forked off the truffle package) to use a private key rather than a mnemonic to deploy contracts. This works much better for me since I can use my MetaMask account's private key to deploy. I use this all the time, so it would be useful to add it to the official truffle docs.

Please let me know if there are other places I can add this reference as well.