### PR TITLE
Add "Recommendations for Linux" in Tuffle Installation Instructions

### DIFF
--- a/src/docs/truffle/getting-started/installation.md
+++ b/src/docs/truffle/getting-started/installation.md
@@ -130,7 +130,7 @@ $ npm config delete prefix
 $ npm config set prefix $NVM_DIR/versions/node/v11.10.0
 ```
 
-### Install truffle and other packages as a normal user
+### Install Truffle and other packages as a normal user
 
 ```bash
 $ npm install -g truffle

--- a/src/docs/truffle/getting-started/installation.md
+++ b/src/docs/truffle/getting-started/installation.md
@@ -33,7 +33,7 @@ Get a list of all installed packages:
 $ sudo npm list -g --depth=0
 ```
 
-```
+```bash
 /usr/lib 
 |--ganache-cli@6.1.8 
 |--npm@6.7.0 
@@ -42,17 +42,17 @@ $ sudo npm list -g --depth=0
 
 Now we want to remove them
 
-`$ sudo npm remove -g anache-cli`
-
-`$ sudo npm remove -g truffle`
-
-`$ sudo npm remove -g npm`
+```bash
+$ sudo npm remove -g anache-cli
+$ sudo npm remove -g truffle
+$ sudo npm remove -g npm
+```
 
 
 If you have additional packages in the tree, you can also remove them.
 
 
-### Remove node
+#### Remove node
 If you installed node with a the package manager of your Linux distro you can delete the package and skip Remove node and Remove npm. If you installed it manually you have to delete it manually.
 
 We have to find out where node is installed before we can delete it.
@@ -68,7 +68,7 @@ find the location of node_modules node and delete it
 `$ sudo rm /usr/bin/node /usr/share/man/man1/node.1.gz`
 
 
-### Remove npm
+#### Remove npm
 We have to find out where npm is installed before we can delete it.
 
 `$ sudo whereis npm`
@@ -89,8 +89,8 @@ Depending on the linux distribution you might have different paths
 
 Now that we have cleaned up everything we can start with the installation of nvm and node
 
-## Installation of node and npm with nvm
-### Install nvm (node version manager)
+### Installation of node and npm with nvm
+#### Install nvm (node version manager)
 See: https://github.com/creationix/nvm
 
 `$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash`
@@ -98,24 +98,24 @@ See: https://github.com/creationix/nvm
 In order to load the new environment you have to close your console and open a new one
 
 
-### Install node.js with nvm
+#### Install node.js with nvm
 `$ nvm install node # "node" is an alias for the latest version`
 
-### Install the latest npm version
+#### Install the latest npm version
 `$ npm install -g npm`
 
 
-### Delete and reset the npm prefix
+#### Delete and reset the npm prefix
 See: https://stackoverflow.com/questions/34718528/nvm-is-not-compatible-with-the-npm-config-prefix-option
 
 `$ npm config delete prefix`
 
 `$ npm config set prefix $NVM_DIR/versions/node/v11.10.0`
 
-## Install truffle and other packages as a normal user
+### Install truffle and other packages as a normal user
 `$ npm install -g truffle`
 
-## Check the installation
+### Check the installation
 `$ whereis truffle`
 
 If everything went as expected truffle should be installed in:

--- a/src/docs/truffle/getting-started/installation.md
+++ b/src/docs/truffle/getting-started/installation.md
@@ -57,33 +57,37 @@ If you installed node with a the package manager of your Linux distro you can de
 
 We have to find out where node is installed before we can delete it.
 
-`$ whereis node`
+```bash
+$ whereis node
+```
 
 in my case I get the following output
-
-`node: /usr/bin/node /usr/share/man/man1/node.1.gz`
+```bash
+node: /usr/bin/node /usr/share/man/man1/node.1.gz
+```
 
 find the location of node_modules node and delete it
-
-`$ sudo rm /usr/bin/node /usr/share/man/man1/node.1.gz`
+```bash
+$ sudo rm /usr/bin/node /usr/share/man/man1/node.1.gz
+```
 
 
 #### Remove npm
 We have to find out where npm is installed before we can delete it.
-
-`$ sudo whereis npm`
+```bash
+$ sudo whereis npm
+```
 
 in my case I get the follwing output:
-
-`npm: /usr/bin/npm /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1`
-
-`$ sudo ls -l /usr/bin/npm`
-
-`lrwxrwxrwx 1 root root 38 Feb  4 08:47 /usr/bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js`
-
-`$ sudo rm -rf /usr/bin/npm /usr/lib/node_modules/npm/bin/npm`
-
-`$ sudo rm -rf /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1`
+```bash
+npm: /usr/bin/npm /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1
+```
+```bash
+$ sudo ls -l /usr/bin/npm
+lrwxrwxrwx 1 root root 38 Feb  4 08:47 /usr/bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js
+$ sudo rm -rf /usr/bin/npm /usr/lib/node_modules/npm/bin/npm
+$ sudo rm -rf /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1
+```
 
 Depending on the linux distribution you might have different paths
 
@@ -93,34 +97,45 @@ Now that we have cleaned up everything we can start with the installation of nvm
 #### Install nvm (node version manager)
 See: https://github.com/creationix/nvm
 
-`$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash`
+```bash
+$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+```
 
 In order to load the new environment you have to close your console and open a new one
 
 
 #### Install node.js with nvm
-`$ nvm install node # "node" is an alias for the latest version`
+```bash
+$ nvm install node # "node" is an alias for the latest version
+```
 
 #### Install the latest npm version
-`$ npm install -g npm`
+```bash
+$ npm install -g npm
+```
 
 
 #### Delete and reset the npm prefix
 See: https://stackoverflow.com/questions/34718528/nvm-is-not-compatible-with-the-npm-config-prefix-option
 
-`$ npm config delete prefix`
-
-`$ npm config set prefix $NVM_DIR/versions/node/v11.10.0`
+```bash
+$ npm config delete prefix
+$ npm config set prefix $NVM_DIR/versions/node/v11.10.0
+```
 
 ### Install truffle and other packages as a normal user
-`$ npm install -g truffle`
+```bash
+$ npm install -g truffle
+```
 
 ### Check the installation
-`$ whereis truffle`
+```bash
+$ whereis truffle
+```
 
 If everything went as expected truffle should be installed in:
-
-`~/.nvm/versions/node/v11.10.0/bin/truffle`
+```bash
+~/.nvm/versions/node/v11.10.0/bin/truffle
+```
 
 Install the other packages which you had installed as sudo, such as ganache-cli or create-react-app.
-

--- a/src/docs/truffle/getting-started/installation.md
+++ b/src/docs/truffle/getting-started/installation.md
@@ -21,7 +21,7 @@ If you're running Truffle on Windows, you may encounter some naming conflicts th
 
 ## Recommendations for Linux
 
-I you're running Truffle on Linux or MacOS X, you should not install it with sudo, otherwise you might encounter some permission issues. It is recommended to install truffle as a normal user. Before we can install truffle as a normal user we have to cleanup the system. It is also recommended to install nodejs and npm with nvm (node version manager). An advantage of nvm is that you can run different node versions on the same machine.
+If you're running Truffle on Linux or macOS, you should not install it with `sudo`, otherwise you might encounter some permission issues. It is recommended to install Truffle as a normal user. Before we can install Truffle as a normal user, we have to clean-up the system. It is also recommended to install Node.js and NPM with [NVM (Node Version Manager)](https://github.com/creationix/nvm]. An advantage of NVM is that you can run different Node versions on the same machine.
 
 ### Cleanup node and npm
 #### Remove all packages which have been installed with `sudo npm install -g`

--- a/src/docs/truffle/getting-started/installation.md
+++ b/src/docs/truffle/getting-started/installation.md
@@ -18,3 +18,109 @@ Truffle also requires that you have a running Ethereum client which supports the
 ## Recommendations for Windows
 
 If you're running Truffle on Windows, you may encounter some naming conflicts that could prevent Truffle from executing properly. Please see [the section on resolving naming conflicts](/docs/advanced/configuration#resolving-naming-conflicts-on-windows) for solutions.
+
+
+## Recommendations for Linux
+
+I you're running Truffle on Linux or MacOS X, you should not install it with sudo, otherwise you might encounter some permission issues. It is recommended to install truffle as a normal user. Before we can install truffle as a normal user we have to cleanup the system. It is also recommended to install nodejs and npm with nvm (node version manager). An advantage of nvm is that you can run different node versions on the same machine.
+
+### Cleanup node and npm
+#### Remove all packages which have been installed with `sudo npm install -g`
+First we want to find out which packages have been installed with `sudo npm install -g`.
+Get a list of all installed packages:
+
+```bash
+$ sudo npm list -g --depth=0
+```
+
+```
+/usr/lib 
+|--ganache-cli@6.1.8 
+|--npm@6.7.0 
++--truffle@5.0.3
+```
+
+Now we want to remove them
+
+`$ sudo npm remove -g anache-cli`
+
+`$ sudo npm remove -g truffle`
+
+`$ sudo npm remove -g npm`
+
+
+If you have additional packages in the tree, you can also remove them.
+
+
+### Remove node
+If you installed node with a the package manager of your Linux distro you can delete the package and skip Remove node and Remove npm. If you installed it manually you have to delete it manually.
+
+We have to find out where node is installed before we can delete it.
+
+`$ whereis node`
+
+in my case I get the following output
+
+`node: /usr/bin/node /usr/share/man/man1/node.1.gz`
+
+find the location of node_modules node and delete it
+
+`$ sudo rm /usr/bin/node /usr/share/man/man1/node.1.gz`
+
+
+### Remove npm
+We have to find out where npm is installed before we can delete it.
+
+`$ sudo whereis npm`
+
+in my case I get the follwing output:
+
+`npm: /usr/bin/npm /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1`
+
+`$ sudo ls -l /usr/bin/npm`
+
+`lrwxrwxrwx 1 root root 38 Feb  4 08:47 /usr/bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js`
+
+`$ sudo rm -rf /usr/bin/npm /usr/lib/node_modules/npm/bin/npm`
+
+`$ sudo rm -rf /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1`
+
+Depending on the linux distribution you might have different paths
+
+Now that we have cleaned up everything we can start with the installation of nvm and node
+
+## Installation of node and npm with nvm
+### Install nvm (node version manager)
+See: https://github.com/creationix/nvm
+
+`$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash`
+
+In order to load the new environment you have to close your console and open a new one
+
+
+### Install node.js with nvm
+`$ nvm install node # "node" is an alias for the latest version`
+
+### Install the latest npm version
+`$ npm install -g npm`
+
+
+### Delete and reset the npm prefix
+See: https://stackoverflow.com/questions/34718528/nvm-is-not-compatible-with-the-npm-config-prefix-option
+
+`$ npm config delete prefix`
+
+`$ npm config set prefix $NVM_DIR/versions/node/v11.10.0`
+
+## Install truffle and other packages as a normal user
+`$ npm install -g truffle`
+
+## Check the installation
+`$ whereis truffle`
+
+If everything went as expected truffle should be installed in:
+
+`~/.nvm/versions/node/v11.10.0/bin/truffle`
+
+Install the other packages which you had installed as sudo, such as ganache-cli or create-react-app.
+

--- a/src/docs/truffle/getting-started/installation.md
+++ b/src/docs/truffle/getting-started/installation.md
@@ -52,7 +52,7 @@ If you have additional packages in the tree, you can also remove them.
 
 #### Remove node
 
-If you installed node with a the package manager of your Linux distro you can delete the package and skip Remove node and Remove npm. If you installed it manually you have to delete it manually.
+If you installed node with a package manager of your Linux distro you can delete the package and skip Remove node and Remove npm. If you installed it manually you have to delete it manually.
 
 We have to find out where node is installed before we can delete it.
 
@@ -80,7 +80,7 @@ We have to find out where npm is installed before we can delete it.
 $ sudo whereis npm
 ```
 
-in my case I get the follwing output:
+In my case, I get the follwing output:
 
 ```bash
 npm: /usr/bin/npm /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1
@@ -107,7 +107,7 @@ See: https://github.com/creationix/nvm
 $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
 ```
 
-In order to load the new environment you have to close your console and open a new one.
+In order to load the new environment, you have to close your console and open a new one.
 
 #### Install node.js with nvm
 

--- a/src/docs/truffle/getting-started/installation.md
+++ b/src/docs/truffle/getting-started/installation.md
@@ -19,13 +19,13 @@ Truffle also requires that you have a running Ethereum client which supports the
 
 If you're running Truffle on Windows, you may encounter some naming conflicts that could prevent Truffle from executing properly. Please see [the section on resolving naming conflicts](/docs/advanced/configuration#resolving-naming-conflicts-on-windows) for solutions.
 
-
 ## Recommendations for Linux
 
 I you're running Truffle on Linux or MacOS X, you should not install it with sudo, otherwise you might encounter some permission issues. It is recommended to install truffle as a normal user. Before we can install truffle as a normal user we have to cleanup the system. It is also recommended to install nodejs and npm with nvm (node version manager). An advantage of nvm is that you can run different node versions on the same machine.
 
 ### Cleanup node and npm
 #### Remove all packages which have been installed with `sudo npm install -g`
+
 First we want to find out which packages have been installed with `sudo npm install -g`.
 Get a list of all installed packages:
 
@@ -48,11 +48,10 @@ $ sudo npm remove -g truffle
 $ sudo npm remove -g npm
 ```
 
-
 If you have additional packages in the tree, you can also remove them.
 
-
 #### Remove node
+
 If you installed node with a the package manager of your Linux distro you can delete the package and skip Remove node and Remove npm. If you installed it manually you have to delete it manually.
 
 We have to find out where node is installed before we can delete it.
@@ -61,27 +60,32 @@ We have to find out where node is installed before we can delete it.
 $ whereis node
 ```
 
-in my case I get the following output
+In my case I get the following output.
+
 ```bash
 node: /usr/bin/node /usr/share/man/man1/node.1.gz
 ```
 
-find the location of node_modules node and delete it
+Find the location of node_modules node and delete it.
+
 ```bash
 $ sudo rm /usr/bin/node /usr/share/man/man1/node.1.gz
 ```
 
-
 #### Remove npm
+
 We have to find out where npm is installed before we can delete it.
+
 ```bash
 $ sudo whereis npm
 ```
 
 in my case I get the follwing output:
+
 ```bash
 npm: /usr/bin/npm /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1
 ```
+
 ```bash
 $ sudo ls -l /usr/bin/npm
 lrwxrwxrwx 1 root root 38 Feb  4 08:47 /usr/bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js
@@ -89,33 +93,36 @@ $ sudo rm -rf /usr/bin/npm /usr/lib/node_modules/npm/bin/npm
 $ sudo rm -rf /usr/share/man/man1/npm.1.gz /usr/share/man/man1/npm.1
 ```
 
-Depending on the linux distribution you might have different paths
+Depending on the linux distribution you might have different paths.
 
-Now that we have cleaned up everything we can start with the installation of nvm and node
+Now that we have cleaned up everything we can start with the installation of nvm and node.
 
 ### Installation of node and npm with nvm
+
 #### Install nvm (node version manager)
+
 See: https://github.com/creationix/nvm
 
 ```bash
 $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
 ```
 
-In order to load the new environment you have to close your console and open a new one
-
+In order to load the new environment you have to close your console and open a new one.
 
 #### Install node.js with nvm
+
 ```bash
-$ nvm install node # "node" is an alias for the latest version
+$ nvm install node # "node" is an alias for the latest version.
 ```
 
 #### Install the latest npm version
+
 ```bash
 $ npm install -g npm
 ```
 
-
 #### Delete and reset the npm prefix
+
 See: https://stackoverflow.com/questions/34718528/nvm-is-not-compatible-with-the-npm-config-prefix-option
 
 ```bash
@@ -124,11 +131,13 @@ $ npm config set prefix $NVM_DIR/versions/node/v11.10.0
 ```
 
 ### Install truffle and other packages as a normal user
+
 ```bash
 $ npm install -g truffle
 ```
 
 ### Check the installation
+
 ```bash
 $ whereis truffle
 ```


### PR DESCRIPTION
Recently I have seen different issues with truffle in the gitter channel and in different issues, which are related to the fact that truffle has been installed with `sudo npm install -g truffle`. Therefore I recommend adding a Recommendations for Linux section to the installation instructions.