### PR TITLE
Show docs sidebar before loading the page instead of after

### DIFF
--- a/helpers/showDocsCategory.js
+++ b/helpers/showDocsCategory.js
@@ -1,0 +1,8 @@
+module.exports = function() {
+  var msPath = arguments[0];
+  var thisCategory = arguments[1];
+
+  var currentCategory = msPath.href.replace(/http(s)?:\/\//, '').split('/')[2];
+
+  return thisCategory === currentCategory ? 'show' : '';
+};

--- a/partials/docs-sidebar.hbs
+++ b/partials/docs-sidebar.hbs
@@ -14,7 +14,7 @@
     <img class="suite-logo" src="/img/truffle-logomark.svg" alt="Truffle Logo" /><h2 class="text-truffle"><span class="narrow">T</span>RUFFLE</h2>
   </a>
 
-  <div class="collapse truffle" id="truffleDocs" data-parent="#docsSidebar">
+  <div class="collapse truffle {{showDocsCategory path "truffle"}}" id="truffleDocs" data-parent="#docsSidebar">
     <ul>
       <a href="/docs/truffle/overview"><li>Overview</li></a>
       <a href="/docs/truffle/quickstart"><li>Quickstart</li></a>
@@ -33,7 +33,7 @@
     <img class="suite-logo" src="/img/ganache-logomark.svg" alt="Ganache Logo" /><h2 class="text-ganache">Ganache</h2>
   </a>
   
-  <div class="collapse ganache" id="ganacheDocs" data-parent="#docsSidebar">
+  <div class="collapse ganache {{showDocsCategory path "ganache"}}" id="ganacheDocs" data-parent="#docsSidebar">
     <ul>
       <a href="/docs/ganache/overview"><li>Overview</li></a>
       <a href="/docs/ganache/quickstart"><li>Quickstart</li></a>
@@ -52,7 +52,7 @@
     <img class="suite-logo" src="/img/drizzle-logomark.svg" alt="Drizzle Logo" /><h2 class="text-drizzle">dri<span class="drizzle-z-skew-1">z</span><span class="drizzle-z-skew-2">z</span>le</h2>
   </a>
   
-  <div class="collapse drizzle" id="drizzleDocs" data-parent="#docsSidebar">
+  <div class="collapse drizzle {{showDocsCategory path "drizzle"}}" id="drizzleDocs" data-parent="#docsSidebar">
     <ul>
       <a href="/docs/drizzle/overview"><li>Overview</li></a>
       <a href="/docs/drizzle/quickstart"><li>Quickstart</li></a>

--- a/src/js/docs.js
+++ b/src/js/docs.js
@@ -1,13 +1,4 @@
-$(function() {  
-  var parsedUrl = new URL(window.location.href);
-
-  // Are we on the docs home page?
-  if (parsedUrl.pathname.length > 2) {
-    var category = parsedUrl.pathname.split('/')[2];
-
-    $('#' + category + 'Docs').collapse('show');
-  }
-
+$(function() {
   $('#docsSidebarToggle').click(function(event) {
     if ($('#docsSidebar').css('position') === 'absolute') {
       $('#docsSidebar').toggleClass('open');


### PR DESCRIPTION
This PR will add the `show` class server-side instead of client-side. This prevents a jarring "it's open, then we close on load, then it opens again" UX.