### PR TITLE
Update Quorum documentation

### DIFF
--- a/src/docs/data.json
+++ b/src/docs/data.json
@@ -12,7 +12,7 @@
       "Debugging Your Contracts",
       "Using Truffle Develop and The Console",
       "Writing External Scripts",
-      "Using Quorum"
+      "Working With Quorum"
     ],
     "Testing": [
       "Testing Your Contracts",

--- a/src/docs/data.json
+++ b/src/docs/data.json
@@ -11,7 +11,8 @@
       "Package Management via NPM",
       "Debugging Your Contracts",
       "Using Truffle Develop and The Console",
-      "Writing External Scripts"
+      "Writing External Scripts",
+      "Using Quorum"
     ],
     "Testing": [
       "Testing Your Contracts",

--- a/src/docs/truffle/getting-started/using-quorum.md
+++ b/src/docs/truffle/getting-started/using-quorum.md
@@ -1,5 +1,0 @@
----
-title: Truffle | Using Quorum
-layout: docs.hbs
----
-# Using Quorum

--- a/src/docs/truffle/getting-started/using-quorum.md
+++ b/src/docs/truffle/getting-started/using-quorum.md
@@ -1,0 +1,5 @@
+---
+title: Truffle | Using Quorum
+layout: docs.hbs
+---
+# Using Quorum

--- a/src/docs/truffle/getting-started/working-with-quorum.md
+++ b/src/docs/truffle/getting-started/working-with-quorum.md
@@ -32,4 +32,7 @@ module.exports = {
 ## Using Privacy Features
 Unfortunately, the privacy features are still not working in version `5` of Truffle. However, they still work in version `4`.
 
-Please refer to the [Quorum tutorial](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains) to learn more about how to use the privacy features within Quorum. Specifically [deploying contracts privately](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#deploying-smart-contracts-on-quorum), [making transactions private](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#using-quorum-39-s-privacy-features-to-make-transactions-private), and [interacting with your contracts privately](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#interacting-with-contracts-privately).
+Please refer to the [Quorum tutorial](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains) to learn more about how to use the privacy features within Quorum. Here are some quick references for privacy within the tutorial:
+- [Deploying contracts privately](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#deploying-smart-contracts-on-quorum)
+- [Making transactions private](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#using-quorum-39-s-privacy-features-to-make-transactions-private)
+- [Interacting with your contracts privately](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#interacting-with-contracts-privately).

--- a/src/docs/truffle/getting-started/working-with-quorum.md
+++ b/src/docs/truffle/getting-started/working-with-quorum.md
@@ -5,7 +5,7 @@ layout: docs.hbs
 # Working With Quorum
 Truffle supports development with Quorum, a version of Ethereum that adds new features on top of what Ethereum already provides. Specifically, **Quorum adds the ability to create private blockchains between select participants, and more importantly adds transaction privacy on top of normal Ethereum transactions.**
 
-It is highly recommended that you read our [tutorial on building a dapp on Quorum](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains) as it goes into more details on working with Quorum.
+It is highly recommended you read our [tutorial on building a dapp on Quorum](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains) before using Truffle with Quorum.
 
 Both the tutorial and this page have been updated for *at least* version `5.0.9` of `truffle`.
 
@@ -21,7 +21,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 22000, // replace with quorum node port you wish to connect to
       network_id: "*",
       type: "quorum"
     }

--- a/src/docs/truffle/getting-started/working-with-quorum.md
+++ b/src/docs/truffle/getting-started/working-with-quorum.md
@@ -1,0 +1,35 @@
+---
+title: Truffle | Working With Quorum
+layout: docs.hbs
+---
+# Working With Quorum
+Truffle supports development with Quorum, a version of Ethereum that adds new features on top of what Ethereum already provides. Specifically, **Quorum adds the ability to create private blockchains between select participants, and more importantly adds transaction privacy on top of normal Ethereum transactions.**
+
+It is highly recommended that you read our [tutorial on building a dapp on Quorum](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains) as it goes into more details on working with Quorum.
+
+Both the tutorial and this page have been updated for *at least* version `5.0.9` of `truffle`.
+
+## Known Issues
+- Quorum support was completely broken in version `5.0.0`, and basic support was restored in `5.0.9`. Make sure you atleast have `5.0.9`
+- The privacy support (via `privateFor`) is still broken in version `5` of Truffle. You must use version `4` (`npm i -g truffle@v4`).
+
+## Configuration
+To use Quorum, you must modify your network in `truffle-config.js` to include a parameter `type` set to `"quorum"`. See the example below.
+
+```javascript
+module.exports = {
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      type: "quorum"
+    }
+  }
+};
+```
+
+## Using Privacy Features
+Unfortunately, the privacy features are still not working in version `5` of Truffle. However, they still work in version `4`.
+
+Please refer to the [Quorum tutorial](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains) to learn more about how to use the privacy features within Quorum. Specifically [deploying contracts privately](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#deploying-smart-contracts-on-quorum), [making transactions private](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#using-quorum-39-s-privacy-features-to-make-transactions-private), and [interacting with your contracts privately](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#interacting-with-contracts-privately).

--- a/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
+++ b/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
@@ -142,7 +142,7 @@ Now that we have Truffle set up, we can move onto code.
 
 ## Deploying smart contracts on Quorum
 
-We won't spend too much time talking about writing or deploying contracts in Truffle since we have [sample documentation](/docs), however we do want to show how deploying contracts applies to Quorum.
+We won't spend too much time talking about writing or deploying contracts in Truffle since we have [ample documentation](/docs), however we do want to show how deploying contracts applies to Quorum.
 
 1. First, copy the following contract into a new file, called `SimpleStorage.sol`. Place it in your `contracts/` directory:
 

--- a/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
+++ b/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
@@ -142,7 +142,7 @@ Now that we have Truffle set up, we can move onto code.
 
 ## Deploying smart contracts on Quorum
 
-We won't spend too much time talking about writing or deploying contracts in Truffle since we have [ample documentation](/docs), however we do want to show how deploying contracts applies to Quorum.
+We won't spend too much time talking about writing or deploying contracts in Truffle since we have [sample documentation](/docs), however we do want to show how deploying contracts applies to Quorum.
 
 1. First, copy the following contract into a new file, called `SimpleStorage.sol`. Place it in your `contracts/` directory:
 

--- a/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
+++ b/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
@@ -114,10 +114,10 @@ To set up Truffle, we're going to start by creating a bare Truffle project, with
 
    If you look at the contents of the `myproject` directory, you'll notice directories were created for you. See the [Truffle documentation](/docs/getting_started/project) for more information about Truffle's project structure.
 
-1. Before moving onto code, we need to configure Truffle to point to our running Quorum client. For this example, we'll edit our `development` network configuration within `truffle.js` to point to the first node available in the 7nodes example:
+1. Before moving onto code, we need to configure Truffle to point to our running Quorum client. For this example, we'll edit our `development` network configuration within `truffle-config.js` to point to the first node available in the 7nodes example:
 
    ```javascript
-   // File: `truffle.js` (edited for 7nodes example)
+   // File: `truffle-config.js` (edited for 7nodes example)
    module.exports = {
      networks: {
        development: {
@@ -125,7 +125,8 @@ To set up Truffle, we're going to start by creating a bare Truffle project, with
          port: 22000, // was 8545
          network_id: "*", // Match any network id
          gasPrice: 0,
-         gas: 4500000
+         gas: 4500000,
+         type: "quorum" // needed for Truffle to support Quorum
        }
      }
    };
@@ -217,10 +218,10 @@ Now that the contract's deployed, it's off to the races.
 
 We originally configured Truffle to point our development environment to the first of the seven nodes provided by the example. You can think of the first node as "us", as if we were developing a dapp for a private network that's used by multiple other parties. Since the 7nodes example provides us seven nodes to work with, we can tell Truffle about the other nodes so we can "be" someone else, and ensure the contract we deployed was private.
 
-1. To add a new network configuration, edit your `truffle.js` file again and add additional network configuration, choosing a network name that best describes the network connection you're adding. In this case, we're going to add a connection to node 4 (`nodefour`) and node 7 (`nodeseven`):
+1. To add a new network configuration, edit your `truffle-config.js` file again and add additional network configuration, choosing a network name that best describes the network connection you're adding. In this case, we're going to add a connection to node 4 (`nodefour`) and node 7 (`nodeseven`):
 
    ```javascript
-   // File: `truffle.js`
+   // File: `truffle-config.js`
    module.exports = {
      networks: {
        development: {
@@ -228,21 +229,24 @@ We originally configured Truffle to point our development environment to the fir
          port: 22000, // was 8545
          network_id: "*", // Match any network id
          gasPrice: 0,
-         gas: 4500000
+         gas: 4500000,
+         type: "quorum" // needed for Truffle to support Quorum
        },
        nodefour:  {
          host: "127.0.0.1",
          port: 22003,
          network_id: "*", // Match any network id
          gasPrice: 0,
-         gas: 4500000
+         gas: 4500000,
+         type: "quorum" // needed for Truffle to support Quorum
        },
        nodeseven:  {
          host: "127.0.0.1",
          port: 22006,
          network_id: "*", // Match any network id
          gasPrice: 0,
-         gas: 4500000
+         gas: 4500000,
+         type: "quorum" // needed for Truffle to support Quorum
        }
      }
    };
@@ -336,7 +340,7 @@ Truffle uses its [truffle-contract](https://github.com/trufflesuite/truffle/tree
 
 Truffle's contract abstraction allow you to make a transaction against any function available on the contract. It does so by evaluating the functions of the contract and making them available to JavaScript. To see these transactions in action, we're going to use an advanced feature of Truffle that lets us execute external scripts within our Truffle environment.
 
-1. Creating a file called `sampletx.js` and save it in the root of your project (the same directory as your `truffle.js` file). Then fill it with this code:
+1. Creating a file called `sampletx.js` and save it in the root of your project (the same directory as your `truffle-config.js` file). Then fill it with this code:
 
    ```javascript
    var SimpleStorage = artifacts.require("SimpleStorage");


### PR DESCRIPTION
This PR updates the Quorum tutorial with the new configuration necessary for Quorum support in Truffle v5 (pending release).

It also adds a section in the docs for Quorum support