### PR TITLE
Document `truffle migrate` --to flag

### DIFF
--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -214,7 +214,7 @@ See the [Package Management with EthPM](/docs/getting_started/packages-ethpm) se
 Run migrations to deploy contracts.
 
 ```shell
-truffle migrate [--reset] [-f <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--dry-run] [--interactive]
+truffle migrate [--reset] [--f <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--dry-run] [--interactive]
 ```
 
 Unless specified, this will run from the last completed migration. See the [Migrations](/docs/getting_started/migrations) section for more details.
@@ -222,7 +222,8 @@ Unless specified, this will run from the last completed migration. See the [Migr
 Options:
 
 * `--reset`: Run all migrations from the beginning, instead of running from the last completed migration.
-* `-f <number>`: Run contracts from a specific migration. The number refers to the prefix of the migration file.
+* `--f <number>`: Run contracts from a specific migration. The number refers to the prefix of the migration file.
+* `--to <number>`: Run contracts to a specific migration. The number refers to the prefix of the migration file.
 * `--network <name>`: Specify the network to use, saving artifacts specific to that network. Network name must exist in the configuration.
 * `--compile-all`: Compile all contracts instead of intelligently choosing which contracts need to be compiled.
 * `--verbose-rpc`: Log communication between Truffle and the Ethereum client.


### PR DESCRIPTION
Documents the `--to` flag for running migration files up to a specific number.

📝 