### PR TITLE
Fix browsersync on windows by removing full path

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -10,10 +10,10 @@ app(false).use(browserSync({
     }
   },
   files: [
-    path.join(__dirname, '../helpers/**/*'),
-    path.join(__dirname, '../layouts/**/*'),
-    path.join(__dirname, '../partials/**/*'),
-    path.join(__dirname, '../src/**/*')
+    'helpers/**/*',
+    'layouts/**/*',
+    'partials/**/*',
+    'src/**/*'
   ],
   port: 9000,
   open: false


### PR DESCRIPTION
According to [this page](https://github.com/paulmillr/chokidar/issues/668#issuecomment-357235531), the full path is technically an invalid glob (hey, I don't make the rules). 

> If you want to use globs, you must ensure that only forward slashes are used as path separators on your input to chokidar.

Can non-Windows users test? 