### PR TITLE
Removing code element not in example codebase causing error

### DIFF
--- a/src/tutorials/drizzle-and-contract-events.md
+++ b/src/tutorials/drizzle-and-contract-events.md
@@ -135,7 +135,7 @@ Redux store that you can use anywhere you can use a store. We will export it to
 be used by `DrizzleProvider`.
 
 ```js
-const appMiddlewares = [ contractEventNotifier, contractErrorNotifier ]
+const appMiddlewares = [ contractEventNotifier ]
 
 export default generateStore({
   drizzleOptions,


### PR DESCRIPTION
See [here](https://github.com/trufflesuite/drizzle-event-demo/blob/master/app/src/middleware/index.js) for the actual example code. 

Thanks for all the great work!