### PR TITLE
Move ga to head

### DIFF
--- a/layouts/layout.hbs
+++ b/layouts/layout.hbs
@@ -49,6 +49,8 @@
   <link href="https://fonts.googleapis.com/css?family=Grand+Hotel|Open+Sans|Oswald|Varela+Round|Roboto+Condensed|Roboto+Mono|Cinzel" rel="stylesheet">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
   <link rel="stylesheet" href="/css/index.css">
+
+  {{> ga-tag}}
 </head>
 <body>
   {{> navbar}}
@@ -56,7 +58,5 @@
   {{{ contents }}}
 
   {{> footer}}
-
-  {{> ga-tag}}
 </body>
 </html>


### PR DESCRIPTION
Google Optimize not picking up tag at end of `body`, so I'm moving it to the `head` element in an attempt to fix.