### PR TITLE
Promote TruffleCon 2019 with a banner and a speaker CTA

### DIFF
--- a/src/events/data.json
+++ b/src/events/data.json
@@ -5,7 +5,7 @@
     "end": "Sunday, Aug 4, 2019, 6:00 PM PST",
     "location": "Microsoft Building 33 | 16070 NE 36th Way, Redmond, WA 98052",
     "excerpt": "TruffleCon is a gathering for Truffle users, fans, developers, and those who want to build world-changing applications powered by decentralized technologies. Join people from around the world as we meet August 2-4 in Redmond, WA to build community and foster connections in the blockchain developer space, share tips and tricks, challenges and successes.",
-    "eventbrite": "https://truffleframework.com/trufflecon2019",
+    "eventbrite": "/trufflecon2019",
     "status": "open",
     "image": "/img/trufflecon.jpg"
   }

--- a/src/index.html
+++ b/src/index.html
@@ -24,6 +24,14 @@ layout: layout.hbs
   </div>
 </div>-->
 
+<div class="banner banner-green banner-trufflecon pt-2 pb-2">
+  <a href="/trufflecon2019">
+    <div class="container text-center">
+      Join us <strong>August 2 - 4</strong> for TruffleCon 2019 @ Microsoft in <u>Redmond, WA</u>!
+    </div>
+  </a>
+</div>
+
 <main role="main" class="container pb-6">
   <div class="row home-heading-row">
     <div class="col text-center">

--- a/src/sass/global/banners.scss
+++ b/src/sass/global/banners.scss
@@ -42,6 +42,10 @@
   background-color: #F7A34E;
 }
 
+.banner-green {
+  background-color: #3fe0c5;
+}
+
 // "Like the Taste"
 
 .banner-taste {
@@ -105,5 +109,21 @@
 
   @media (max-width: 991.98px) {
     
+  }
+}
+
+.banner-trufflecon {
+  color: white;
+  font-weight: bold;
+  text-decoration: none;
+
+  a {
+    text-decoration: none;
+    color: #58484e;
+
+    &:hover {
+      color: white;
+      text-decoration: none;
+    }
   }
 }

--- a/src/sass/pages/trufflecon.scss
+++ b/src/sass/pages/trufflecon.scss
@@ -196,6 +196,10 @@ blockquote {
   }
 }
 
+.speak-at-cta {
+  margin-left: 0.5rem;
+}
+
 .trufflecon-opening {
   font-size: 1.5rem;
   font-style: italic;

--- a/src/trufflecon2019.html
+++ b/src/trufflecon2019.html
@@ -38,7 +38,7 @@ layout: layout.hbs
           <div class="mt-4 mb-4"></div>
           <div class="text-center">
             <a class="btn btn-truffle btn-lg" href="https://www.eventbrite.com/e/trufflecon-2019-tickets-58020862963?aff=TruffleCon2019" target="_blank">Secure Your Spot</a>
-            <a class="btn btn-ganache btn-lg" href="/trufflecon2019#speak-at">Speak at TruffleCon</a>
+            <a class="btn btn-ganache btn-lg speak-at-cta" href="/trufflecon2019#speak-at">Speak at TruffleCon</a>
           </div>
       </div>
     </div>

--- a/src/trufflecon2019.html
+++ b/src/trufflecon2019.html
@@ -38,6 +38,7 @@ layout: layout.hbs
           <div class="mt-4 mb-4"></div>
           <div class="text-center">
             <a class="btn btn-truffle btn-lg" href="https://www.eventbrite.com/e/trufflecon-2019-tickets-58020862963?aff=TruffleCon2019" target="_blank">Secure Your Spot</a>
+            <a class="btn btn-ganache btn-lg" href="/trufflecon2019#speak-at">Speak at TruffleCon</a>
           </div>
       </div>
     </div>
@@ -312,11 +313,11 @@ layout: layout.hbs
 
 </main>
 
-<main class="banner banner-white-choc pt-5 pb-5">
+<main id="speak-at" class="banner banner-white-choc pt-5 pb-5">
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <h1 id="speak-at" class="link-markdown mb-4 mt-4"><a href="#speak-at" name="speak-at"><i class="fas fa-link"></i></a><span class="color-truffle">SPEAK AT TRUFFLECON</span></h1>
+        <h1 class="link-markdown mb-4 mt-4"><a href="#speak-at" name="speak-at"><i class="fas fa-link"></i></a><span class="color-truffle">SPEAK AT TRUFFLECON</span></h1>
         <p>We are now accepting submissions for 15-minute lightning talks, 1-hour talks, and 4-hour workshops. Submissions close April 30, 2019. We will announce speakers by July 1, 2019. All speakers will receive free admission to all three days of TruffleCon. Email <a href="mailto:events@trufflesuite.com" target="_blank">events@trufflesuite.com</a> with any questions. Thank you!
             <br/><br/>
             -The Truffle Team</p>


### PR DESCRIPTION
Visible changes below. Also edited a few items that bugged me: 

- The `speak-at` id, when clicked, made half the "Speak at Trufflecon" explainer text covered up by the nav. So I moved it higher.
- "Read More" on the events page linked directly to `truffleframework.com`, making development hard (I was confused for a second why my changes weren't showing up. 

Banner:
![image](https://user-images.githubusercontent.com/92629/56326425-ce597280-612a-11e9-97f5-3fdd473b4407.png)

Speaker CTA:
![image](https://user-images.githubusercontent.com/92629/56326442-de715200-612a-11e9-8b7c-dffd97221d55.png)
