### PR TITLE
Added migrations_directory key

### DIFF
--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -181,6 +181,25 @@ module.exports = {
 
 Absolute paths will also work. This is not recommended though, as an absolute path may not exist when compiled on another system. If you use absolute paths on Windows, make sure to use double backslashes for paths (example: `C:\\Users\\Username\\output`).
 
+### migrations_directory
+The default migrations directory is `./migrations` relative to the project root. This can be changed with the `migrations_directory` key.
+
+ Example:
+
+```javascript
+module.exports = {
+  migrations_directory: "./allMyStuff/someStuff/theMigrationsFolder",
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+    }
+  }
+};
+```
+
+
 ### mocha
 
 Configuration options for the [MochaJS](http://mochajs.org/) testing framework. This configuration expects an object as detailed in Mocha's [documentation](https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options).


### PR DESCRIPTION
**Motivation**
It happened due to the requirement of project structure, I was forced to move the **contracts, build, and migrations** directory to a customized location other than the **project root**.
In order to configure these changes, such that **truffle compile** and **truffle migrate** works as expected I went through these [truffle.config.js configuration](https://truffleframework.com/docs/truffle/reference/configuration).
I was able to figure out that for specifying a custom location for **contracts and build** directory, truffle provides **contracts_directory and contracts_build_directory** keys.
However, since the **migrations** folder too, was moved, hence, while executing **truffle migrate** it emitted an error:
`Error: ENOENT: no such file or directory, stat '/path/to/migrations' directory` 

In order to solve the above issue, I added **migrations_directory** key in the **truffle.config.js** file and it worked !!!

However, this piece of information was missing in the documentation, thus created a PR for the same.
Hope it helps.

**What I did?**

Added _migrations_directory_ key in **truffle.config.js** file

`Truffle version details:`
```
Truffle v5.0.2 (core: 5.0.2)
Solidity v0.5.0 (solc-js)
Node v10.14.1
```



