### PR TITLE
Fix EthPM registry explorer link

### DIFF
--- a/src/docs/truffle/getting-started/package-management-via-ethpm.md
+++ b/src/docs/truffle/getting-started/package-management-via-ethpm.md
@@ -20,7 +20,7 @@ You can also install a package at a specific version:
 $ truffle install <package name>@<version>
 ```
 
-Like NPM, EthPM versions follow [semver](http://semver.org/). You can find a list of all available packages at [the Ethereum Package Registry](https://www.ethpm.com/registry).
+Like NPM, EthPM versions follow [semver](http://semver.org/). You can find a list of all available packages at [the Ethereum Package Registry](http://explorer.ethpm.com/).
 
 ## Installing Dependencies
 


### PR DESCRIPTION
Broken link in the [EthPM documentation](https://truffleframework.com/docs/truffle/getting-started/package-management-via-ethpm) is fixed.