### PR TITLE
Add warning about NodeJS 12

### DIFF
--- a/src/docs/truffle/getting-started/installation.md
+++ b/src/docs/truffle/getting-started/installation.md
@@ -10,8 +10,10 @@ npm install -g truffle
 
 ## Requirements
 
-* NodeJS v8.9.4 or later
+* NodeJS v8.9.4 - v11.15.0
 * Windows, Linux or Mac OS X
+
+Because of [the bug](https://github.com/trufflesuite/truffle/issues/2070), Truffle is not usable on NodeJS 12 or later.
 
 Truffle also requires that you have a running Ethereum client which supports the standard JSON RPC API (which is nearly all of them). There are many to choose from, and some better than others for development. We'll discuss them in detail in the [Choosing an Ethereum client](/docs/getting_started/client) section.
 


### PR DESCRIPTION
I've added warning about NodeJS 12. This is related to https://github.com/trufflesuite/truffle/issues/2070#issuecomment-501699184.