### PR TITLE
truffle test: Describe the exit status

### DIFF
--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -298,7 +298,13 @@ Run JavaScript and Solidity tests.
 truffle test [<test_file>] [--compile-all] [--network <name>] [--verbose-rpc] [--show-events]
 ```
 
-Runs some or all tests within the `test/` directory as specified. See the section on [Testing your contracts](/docs/getting_started/testing) for more information.
+Runs some or all tests within the `test/` directory as specified.
+
+See the section on [Testing your contracts](/docs/getting_started/testing) for more information.
+
+Exit status:
+
+* Per mocha's [source code](https://github.com/mochajs/mocha/blob/5d4dd98747637d0e7ed3007328ec9627dd7eda41/lib/cli/run-helpers.js#L35): typically, the exit status is the number of failed tests or 255 if there has been more than 255 failed tests.
 
 Options:
 


### PR DESCRIPTION
Per https://github.com/trufflesuite/truffle/issues/2155

Truffle documentation does not describe the exit status of `truffle
test` command. Neither does `mocha`, except in its source code.

The changes introduced by this commit may benefit the project in these
ways:
  - Providing a link to `mocha` source code shows that the issue is not
  caused by `truffle`
  - Users searching for `mocha exit status` may find the answer in
  `truffle` documentation, which increases awareness of the project