### PR TITLE
Add Hyperledger Fabric EVM docs

### DIFF
--- a/src/docs/data.json
+++ b/src/docs/data.json
@@ -27,7 +27,8 @@
       "Debugging Your Contracts",
       "Using Truffle Develop and The Console",
       "Writing External Scripts",
-      "Working With Quorum"
+      "Working With Quorum",
+      "Working With Hyperledger EVM"
     ],
     "Testing": [
       "Testing Your Contracts",

--- a/src/docs/truffle/getting-started/working-with-hyperledger-evm.md
+++ b/src/docs/truffle/getting-started/working-with-hyperledger-evm.md
@@ -1,0 +1,22 @@
+---
+title: Truffle | Working With Hyperledger EVM
+layout: docs.hbs
+---
+# Working With Hyperledger EVM
+As of version `5.0.27`, Truffle supports development with Hyperledger Fabric's EVM chaincode, a **permissioned** version of Ethereum.
+
+## Configuration
+To use Fabric EVM, you must modify your network in `truffle-config.js` to include a parameter `type` set to `"fabric-evm"`. See the example below.
+
+```javascript
+module.exports = {
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 5000, // default Fab3 port
+      network_id: "*",
+      type: "fabric-evm"
+    }
+  }
+};
+```


### PR DESCRIPTION
This PR adds a preliminary section in the docs for Hyperledger Fabric EVM support (as of Truffle v5.0.27).