### PR TITLE
Edit command docs

### DIFF
--- a/src/docs/truffle/getting-started/using-truffle-develop-and-the-console.md
+++ b/src/docs/truffle/getting-started/using-truffle-develop-and-the-console.md
@@ -108,16 +108,17 @@ If you wish to see information regarding RPC activity during your Truffle
 develop session, you can use the `--log` option.
 
 When you run `truffle develop --log`, Truffle will start up a new develop
-session and output the addresses and keys as illustrated in the previous section.
-However, in this terminal window you will not be able to interact through the
-console as it will only output the RPC activity occurring on the network. If
+session and output the addresses and keys as described in the previous section.
+However, in this terminal window you will not be able to interact with the
+console like you would in a normal Truffle develop session. Instead it will
+only output the RPC activity occurring on the network. If
 you want to interact with the console, you will have to open a new terminal
-window and connect to the already running Truffle develop session.
+window and connect to the current session by running `truffle develop`.
 
 If you already have a Truffle develop session running and want to log all
-RPC activity occurring on it, you can also run `truffle develop --log` in a
-separate terminal window and it will connect to the currently-running session.
-It will then act the same way as described above.
+RPC activity occurring on it, you can run `truffle develop --log` in a
+separate terminal window. It will then connect to that session
+and act the same way as described above.
 
 
 #### Configuring Truffle Develop

--- a/src/docs/truffle/getting-started/using-truffle-develop-and-the-console.md
+++ b/src/docs/truffle/getting-started/using-truffle-develop-and-the-console.md
@@ -102,6 +102,24 @@ This shows you the addresses, private keys, and mnemonic for this particular blo
 </p>
 
 
+#### Log RPC Activity
+
+If you wish to see information regarding RPC activity during your Truffle
+develop session, you can use the `--log` option.
+
+When you run `truffle develop --log`, Truffle will start up a new develop
+session and output the addresses and keys as illustrated in the previous section.
+However, in this terminal window you will not be able to interact through the
+console as it will only output the RPC activity occurring on the network. If
+you want to interact with the console, you will have to open a new terminal
+window and connect to the already running Truffle develop session.
+
+If you already have a Truffle develop session running and want to log all
+RPC activity occurring on it, you can also run `truffle develop --log` in a
+separate terminal window and it will connect to the currently-running session.
+It will then act the same way as described above.
+
+
 #### Configuring Truffle Develop
 
 You can configure `truffle develop` to use any of the available

--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -132,7 +132,7 @@ Alias for `migrate`. See [migrate](/docs/truffle/reference/truffle-commands#migr
 Open a console with a development blockchain
 
 ```shell
-truffle develop
+truffle develop [--log]
 ```
 
 Spawns a local development blockchain, and allows you to interact with contracts via the command line. Additionally, many Truffle commands are available within the console (without the `truffle` prefix).
@@ -140,6 +140,13 @@ Spawns a local development blockchain, and allows you to interact with contracts
 If you want an interactive console but want to use an existing blockchain, use `truffle console`.
 
 See the [Using the console](/docs/getting_started/console) section for more details.
+
+
+Option:
+
+* `--log`: Start/Connect to a Truffle develop session and log all RPC activity.
+See the [Log RPC Activity](docs/getting_started/console#log-rpc-activity)
+docs for more information about using this option.
 
 
 ### exec


### PR DESCRIPTION
Add some information to the page documenting the Truffle console/develop features relating to the `--log` option for `truffle develop`. This option was previously undocumented.