### PR TITLE
Remove the word "now" from TS test file docs

### DIFF
--- a/src/docs/truffle/testing/writing-tests-in-javascript.md
+++ b/src/docs/truffle/testing/writing-tests-in-javascript.md
@@ -221,4 +221,4 @@ Truffle gives you access to Mocha's configuration so you can change how Mocha be
 
 ## TypeScript File Support
 
-Truffle now supports tests saved as a `.ts` [TypeScript](https://www.typescriptlang.org/) file. Please see the [Writing Tests in JavaScript](#writing-tests-in-javascript) guide for more information.
+Truffle supports tests saved as a `.ts` [TypeScript](https://www.typescriptlang.org/) file. Please see the [Writing Tests in JavaScript](#writing-tests-in-javascript) guide for more information.


### PR DESCRIPTION
Users reading this document have no concept of when the document was written, and so have no point of reference to understand the "now". Additionally, readers unaware of Truffle's past will be reminded of a time Truffle was less awesome, even if they never lived it (e.g., saying something is "now supported" immediately references a time where it wasn't). Instead, we should just remove the "now" and flex our Typescript muscles like it ain't no thang. Feel me? 💪