### PR TITLE
Fix: canonical URLs are truncated

### DIFF
--- a/helpers/getPageUrl.js
+++ b/helpers/getPageUrl.js
@@ -1,3 +1,5 @@
+var path = require("path");
+
 module.exports = function() {
   var msPath = arguments[0];
 
@@ -6,6 +8,5 @@ module.exports = function() {
   }
 
   var url = msPath.href;
-
-  return 'https://trufflesuite.com' + url.substring(0, url.length - 5);
+  return 'https://trufflesuite.com' + url.substring(0, url.length - path.extname(url).length);
 };


### PR DESCRIPTION
Previously we used `.html` as our file extension. Now that we use md the previous way we strip the extension doesn't work. Update it to be a more generic approach to the problem.

I haven't tested this at all. Sorry (not sorry).