### PR TITLE
remove truffleCon header/footer ads

### DIFF
--- a/src/blog/10-things-we-dont-do-that-make-working-at-truffle-awesome.md
+++ b/src/blog/10-things-we-dont-do-that-make-working-at-truffle-awesome.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 ![tapestry of Truffle team headshots](/img/blog/10-things-we-dont-do-that-make-working-at-truffle-awesome/layer-1.jpg)
 
 At Truffle we have an extremely tight-knit team. You'll see that at this year's TruffleCon, a conference for hundreds of attendees organized by only a handful of people. We often have more work than we can handle, yet we take it on because we love the work we're doing and we love the people we work with. In my history of hopping startups – I'm currently on number nine – I haven't seen this anywhere else, so I wanted to take the time to highlight some things that set Truffle apart from the rest. Here's a list of what we don't do that makes working at Truffle awesome:
@@ -30,10 +22,3 @@ Working at Truffle has been an amazing journey. It's incredibly humbling to see 
 
 ![Truffle team members preparing for TruffleCon 2019](/img/blog/10-things-we-dont-do-that-make-working-at-truffle-awesome/layer-7.jpg)
 
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/3-ways-enterprises-are-addressing-blockchain-privacy-concerns.md
+++ b/src/blog/3-ways-enterprises-are-addressing-blockchain-privacy-concerns.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 [Blockchain has been touted as the great connector to integrate businesses under consortium networks](https://www.forbes.com/sites/andrewarnold/2019/02/21/why-2019-may-become-the-year-of-enterprise-blockchain/#66c9e516427e). It’s ability to verify data using smart contracts and provide transparency across network participants through immutable shared data has people talking about a technical revolution. However, this benefit has been a double-edged sword because the enterprise world is skeptical about sharing sensitive data on a ledger where the information cannot be deleted. The good news is, this year has seen numerous announcements of single and multi-party blockchain pilots by the Fortune 500 such as… [Starbucks](https://news.microsoft.com/transform/starbucks-turns-to-technology-to-brew-up-a-more-personal-connection-with-its-customers/) and [MetLife](https://www.forbes.com/sites/stevenehrlich/2019/06/19/metlife-plans-to-disrupt-2-7-trillion-life-insurance-industry-using-ethereum-blockchain/#3e9a87277022). Data privacy issues haven’t stopped them and the enterprise blockchain world has taken these steps to shift their thinking.
 
 ## 1. Store references to data on the blockchain
@@ -26,11 +18,3 @@ Finally, with all the hype on blockchain’s potential in the last years, we hav
 West Monroe is a national business and technology consulting firm that partners with dynamic organizations to reimagine, build, and operate their businesses at peak performance. Our team of more than 1,400 professionals across nine offices is comprised of an uncommon blend of business consultants and deep technologists. I am one of those consultants and I am one of the leaders of our blockchain center of excellence. I’ll be presenting on Sunday morning (8/4) about one of our blockchain projects that looks to [incentivize electric vehicle owners to charge with cleaner energy](https://trufflecon2019.sched.com/event/RHIR/driving-renewable-energy-usage-with-blockchain-and-electric-vehicles). Check us out at our [website](https://www.westmonroepartners.com/) and read more about our [blockchain perspectives](https://blog.westmonroepartners.com/?s=blockchain) on our blog!
 
 Danny Pan is a consultant with West Monroe Partner’s Seattle Technology Practice. He focuses on providing value in adopting blockchain, distributed technologies, and robust SDLC practices. Contact Danny at [dpan@wmp.com](mailto:dpan@wmp.com)
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Join Danny along with 60+ speakers at TruffleCon 2019 in Redmond, WA August 2-4!
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/5-trends-impacting-the-blockchain-developer-experience.md
+++ b/src/blog/5-trends-impacting-the-blockchain-developer-experience.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 In this article we explore 5 trends impacting the developer-experience (or DX) when it comes to building blockchain-based solutions. Specifically, applications and services that leverage a blockchain or distributed ledger or as part of their overall architecture.
 
 This is, of course, is by no means a definitive list. As with everything in the industry, change is happening fast and as such, this is more of a selection of trends that are on the team’s radar. If there’s anything we’ve missed or should know about, we’d love to hear from you (or speak in person at [TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)).
@@ -14,7 +6,7 @@ This is, of course, is by no means a definitive list. As with everything in the 
 
 Obviously we’re a little biased, but in this case, we’re talking about tools and utilities that are not [chocolate-themed](https://www.trufflesuite.com/). It’s literally every day we collectively come across something new that makes our lives as developers (or users, auditors, admins, etc) easier.
 
-This is a big deal for the long-term success of the wider ecosystem because happy and productive developers obviously strongly correlates with increased experimentation, the volume of shipped products and services, and expedites the process of on-boarding new people (developers or otherwise) into the blockchain space. 
+This is a big deal for the long-term success of the wider ecosystem because happy and productive developers obviously strongly correlates with increased experimentation, the volume of shipped products and services, and expedites the process of on-boarding new people (developers or otherwise) into the blockchain space.
 
 At Truffle, we’re also pushing harder than ever to make the DX as sweet as possible. Like, raspberry truffle sweet. This includes new features and enhancements to the existing suite (such as integration with [Hyperledger Fabric's chaincode EVM](https://github.com/trufflesuite/truffle/releases/tag/v5.0.27)), as well as the upcoming [Truffle DB](https://www.trufflesuite.com/blog/introducing-truffle-db-part-1) and [Truffle Teams](https://www.trufflesuite.com/teams).
 
@@ -40,7 +32,7 @@ It’s almost too easy. Seriously though, this evolution of developer experience
 
 While veteran projects like [OpenZeppelin](https://openzeppelin.org/) continue to blossom, one interesting trend we’ve seen is larger organizations’ increasing embrace of open-source with the recent release of some exciting new projects.
 
-Some great examples of this include Ernst & Young’s [Nightfall](https://github.com/EYBlockchain/nightfall), Samsung’s [Blockchain SDK](https://developer.samsung.com/blockchain), Microsoft’s [Confidential Consortium Framework](https://github.com/microsoft/CCF), and the continued evolution of the JPMorgan-backed [Quorum](https://github.com/jpmorganchase/quorum). We’re equally pumped by the launch of Cloudflare’s [Ethereum gateway](https://blog.cloudflare.com/cloudflare-ethereum-gateway/) too! 
+Some great examples of this include Ernst & Young’s [Nightfall](https://github.com/EYBlockchain/nightfall), Samsung’s [Blockchain SDK](https://developer.samsung.com/blockchain), Microsoft’s [Confidential Consortium Framework](https://github.com/microsoft/CCF), and the continued evolution of the JPMorgan-backed [Quorum](https://github.com/jpmorganchase/quorum). We’re equally pumped by the launch of Cloudflare’s [Ethereum gateway](https://blog.cloudflare.com/cloudflare-ethereum-gateway/) too!
 
 It’s exciting to see companies of all shapes and sizes embracing the paradigm in ways that we can all benefit.
 
@@ -53,11 +45,3 @@ We’re rapidly seeing the decentralized equivalent of swaths of traditional fin
 And of course it goes far beyond finance. Everything from supply chains to in-game assets are steadily turning Ethereum into the “[global platform for every asset](https://twitter.com/MuteDialog/status/1149047398532075526)”.
 
 **It’s never been a better time to building on Ethereum. From tooling to infrastructure to a world-class open-source ecosystem, the developer-experience continues to blossom.**
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/an-easier-way-to-deploy-your-smart-contracts.md
+++ b/src/blog/an-easier-way-to-deploy-your-smart-contracts.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](/trufflecon2019)** is happening August 2-4 on Microsoft's campus in Redmond, WA. This year's event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that's on our minds. We hope you enjoy and we'll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 **TL;DR** - Deploying your smart contracts shouldn't be difficult, and the process should be flexible. I give a sneak peek at the next feature we're building: an **easy to use interface to deploy your Truffle projects with [Truffle Teams](/teams)**! It's going to be awesome, and **you can be the first to use it**! I'll be giving a **hands-on workshop from 9AM-12PM on Friday, August 2nd, at [TruffleCon 2019](/trufflecon2019)** that will walk you through through the entire Truffle Teams lifecycle, including the **never-before-used Deployments interface**! See you there!
 
 ---
@@ -179,15 +171,3 @@ But we're not done yet! You've finished your testing on Ropsten, and you're now 
 I really hope you're going to TruffleCon; it's going to be awesome. Even more so because you can **be the first to try Truffle Teams Deployments in my workshop!** In my `Push It! Push It Real Good: Truffle Teams Intro & Deployments` (9AM-12PM on Friday, Aug, 2nd) workshop, we'll cover this entire lifecycle: hooking up your repository, getting your first build to pass, deploying to Ropsten, and finally monitoring transactions made against your contracts (we didn't talk about this here; check out the [docs](/docs/teams/contracts/contract-monitoring) for more details on contract monitoring).
 
 Hopefully there will be time for me to answer any questions you have, and maybe even help get your own Truffle project hooked up with Truffle Teams! If not, I will be available during the office hours at 5PM on Friday! I'm also always happy to chat anytime throughout the conference!
-
-**You can reserve your spot in my workshop [here](https://trufflecon2019.sched.com/event/RFHD/push-it-push-it-real-good-truffle-teams-intro-deployments)!**
-
-Haven't bought your ticket to TruffleCon yet, and really want to get your hands on this cool feature?? It's not too late! Hope to see you there 👇
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/axonis-enterprise-use-of-truffle.md
+++ b/src/blog/axonis-enterprise-use-of-truffle.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](/trufflecon2019)** is happening August 2-4 on Microsoft's campus in Redmond, WA. This year's event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that's on our minds. We hope you enjoy and we'll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 ![Truffle + Axoni](/img/blog/axonis-enterprise-use-of-truffle/truffle-axoni.png)
 
 ## Axoni Background
@@ -59,17 +51,17 @@ In terms of implementation, a truffle exec script reads this configuration file,
 const run = async (done) => {
     let jobParams = args;
 
-        // Configure specific variables for a PROD-like environment: 
+        // Configure specific variables for a PROD-like environment:
     if (process.env.ENV === 'PROD') {
         jobParams = Object.assign(args, handleProd());
     }
 
        //hoisting injected vars to global scope:
-    global.web3 = web3; 
-    global.artifacts = artifacts; 
+    global.web3 = web3;
+    global.artifacts = artifacts;
 
         // Create instance of job based on type
-    const jobInstance = new Job(jobParams.job, jobParams); 
+    const jobInstance = new Job(jobParams.job, jobParams);
 
         //Run job by deploying and invoking an initialization method on each contract
     await jobInstance.run().catch(e => done(e));
@@ -92,10 +84,3 @@ In the meantime, we hope the above at least provides a high-level example of an 
 
 The Axoni team and I look forward to discussing this topic and much more (such as [Axlang, our Scala-based Solidity-alternative](https://axoni.com/axlang/)) at Trufflecon.
 
-<div class="post-trufflecon-box mt-5 text-center">
-  Join Jonathan along with 60+ speakers at TruffleCon 2019 in Redmond, WA August 2-4!
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/best-methods-to-understand-blockchain-if-youre-not-a-developer.md
+++ b/src/blog/best-methods-to-understand-blockchain-if-youre-not-a-developer.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](/trufflecon2019)** is happening August 2-4 on Microsoft's campus in Redmond, WA. This year's event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that's on our minds. We hope you enjoy and we'll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 As a non-technical person, it feels like it takes 1.21 gigawatts to keep up with the speed of technology - even Doc Brown himself couldn't have predicted all of the technological advancements with his flux capacitor. Not only are we trying to keep up with technologies like blockchain, machine learning, and AI, but we have an overwhelming amount of information on the web all at the click of a mouse. It's overwhelming to the point that it's difficult to even know where to begin. However, online blockchain educational materials have started to ramp up. As I write this, I'm confident I'll start seeing “ Blockchain for dummies” online course advertisements on my browser (Opt-in, of course, because I'm using Brave). Mind-blowing! Let me help you begin by slowing down in order to speed up effectively.
 
 So you're someone who's not technical that wants to learn blockchain - great! Whether you're technical or non-technical isn't necessarily contingent on understanding an emerging technology like blockchain. Rather it's how you position yourself in the marketplace where you'll start to see the fruits of your labor.
@@ -41,11 +33,3 @@ Listening to a [Podcast](https://player.fm/podcasts/Blockchain) is great. Especi
 </h3>
 
 Finally, and I may be a little bias, but if you really want to increase the pace at which you can comprehend blockchain then go to TruffleCon! Come say hi to all of us at Truffle. Come say hello to all of the speakers and blockchain company representatives. Ask us questions. Let us help you understand blockchain better. Let's network. Let's have a relationship that will enable amicability. Or better yet, let's interop with each other to leverage the power of blockchain for careers, security, and better transparency in an ever-growing technological world, one node at a time.
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/blockchain-will-cure-cancer.md
+++ b/src/blog/blockchain-will-cure-cancer.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](/trufflecon2019)** is happening August 2-4 on Microsoft's campus in Redmond, WA. This year's event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that's on our minds. We hope you enjoy and we'll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 <p style="width: 40%; float: left; margin-right: 1rem;">
   <img style="margin-top: 0.3rem; margin-bottom: 0;" class="img-fluid" src="/img/blog/blockchain-will-cure-cancer/laptop.jpg" title="Laptop" alt="Laptop">
 </p>
@@ -48,10 +40,3 @@ While it does not appear that cancer fundraising has made its way onto a blockch
 
 Blockchain technology is still in early stages, and it may be too soon to know precisely in which ways it may change our world. Developments in the medical applications of blockchain technology are very encouraging. Cancer has evaded a cure for many years, and the advent of new ways for scientists and physicians to learn, collaborate, and experiment may be just what the medical community needs.
 
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/crytic-continuous-assurance-for-smart-contracts.md
+++ b/src/blog/crytic-continuous-assurance-for-smart-contracts.md
@@ -1,12 +1,4 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
-We are proud to announce our new Smart contract security product: [https://crytic.io/](https://crytic.io/). Crytic provides continuous assurance for smart contracts. The platform reports build status on every commit and runs a suite of security analyses for immediate feedback. 
+We are proud to announce our new Smart contract security product: [https://crytic.io/](https://crytic.io/). Crytic provides continuous assurance for smart contracts. The platform reports build status on every commit and runs a suite of security analyses for immediate feedback.
 
 The beta access will be open soon. Follow us [on twitter](https://twitter.com/CryticCI) to be notified and benefit from the service as soon as possible! The first three months are free.
 
@@ -80,11 +72,3 @@ We are constantly improving Crytic. Expect to see new bug detectors and new feat
 Questions? Bring them to TruffleCon, and pose them to us at our booth or at our Friday workshop [on automated vulnerability detection tools](https://trufflecon2019.sched.com/event/RFQL/how-to-build-secure-smart-contracts-a-deep-dive-into-automated-tools?iframe=no&w=100%&sidebar=yes&bg=no)!
 
 Whether or not you can make it to TruffleCon, join our [slack channel](https://empireslacking.herokuapp.com/) (#crytic) for support, and watch [@CryticCI](https://twitter.com/CryticCI) to find out as soon as our beta is open.
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/develop-using-fluidity-truffle-box.md
+++ b/src/blog/develop-using-fluidity-truffle-box.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 **TLDR;** Fluidity has a pretty awesome truffle-box with lots of goodies to build secure, well-tested smart contracts. With two simple commands, you’ll be set up for development using these testing and security tools preconfigured.
 
 To use:
@@ -23,12 +15,12 @@ The Fluidity Truffle Box allows us to bootstrap our smart contract projects. Thi
 
 ## Core Tools
 
-At Fluidity we write smart contracts with Solidity using the latest fixed version, currently 0.5.10, and we use Ganache as our primary test chain. We use Open-Zeppelin as the base for many of our contracts’ systems. In addition, there’s a linter for both the smart contracts and tests using [solhint](https://www.npmjs.com/package/solhint) and [standard](https://www.npmjs.com/package/standard). A linter analyzes code and tests and then either recommends or updates the code for potential syntax errors and style recommendations. Solhint’s configuration is present in fluidity-truffle-box and tries to closely align with the Solidity documentation. We use standard because it’s opinionated and keeps the codebase consistent with minimal fuss. Thus, standard doesn’t have any custom configurations. 
+At Fluidity we write smart contracts with Solidity using the latest fixed version, currently 0.5.10, and we use Ganache as our primary test chain. We use Open-Zeppelin as the base for many of our contracts’ systems. In addition, there’s a linter for both the smart contracts and tests using [solhint](https://www.npmjs.com/package/solhint) and [standard](https://www.npmjs.com/package/standard). A linter analyzes code and tests and then either recommends or updates the code for potential syntax errors and style recommendations. Solhint’s configuration is present in fluidity-truffle-box and tries to closely align with the Solidity documentation. We use standard because it’s opinionated and keeps the codebase consistent with minimal fuss. Thus, standard doesn’t have any custom configurations.
 
 ## How we handle testing and code coverage
 
 ### Gnosis Mock Contract
-Gnosis-Mock is a comprehensive mocking smart contract that allows us to perform unit-testing of our smart contracts. For those not familiar, mocking means creating dummy objects to simulate the behavior of real objects. Mocking allows one to isolate the behavior of the testable object from any other dependencies. As an example, certain behavior in smart contract designs, such as closing a token sale, may require dependencies on several state variables and contracts to already be triggered to allow it to burn tokens. To close a token sale, let’s say you need to have started the sale, sold some threshold of tokens, reached a certain future block, and given close sale privileges to another user. Any one of these requirements, outside of just calling close sale, would need to be run if mocking were not used. By simulating these states with dummy smart contract, it narrows down exactly what needs to be tested. We heavily use the Gnosis mock library which allows us to test contracts independently before running any integration tests. 
+Gnosis-Mock is a comprehensive mocking smart contract that allows us to perform unit-testing of our smart contracts. For those not familiar, mocking means creating dummy objects to simulate the behavior of real objects. Mocking allows one to isolate the behavior of the testable object from any other dependencies. As an example, certain behavior in smart contract designs, such as closing a token sale, may require dependencies on several state variables and contracts to already be triggered to allow it to burn tokens. To close a token sale, let’s say you need to have started the sale, sold some threshold of tokens, reached a certain future block, and given close sale privileges to another user. Any one of these requirements, outside of just calling close sale, would need to be run if mocking were not used. By simulating these states with dummy smart contract, it narrows down exactly what needs to be tested. We heavily use the Gnosis mock library which allows us to test contracts independently before running any integration tests.
 
 ### Truffle Assertions
 Truffle assertions has streamlined how we test events and states of smart contracts. The packages works inside Truffle tests and provides more assertions to call about smart contract states. It supports revert reason strings so we can be confident that exact cases are hit on revert. In addition, it provides more granular ways to test for function failures.
@@ -49,7 +41,7 @@ At Fluidity we use circle-ci for our continuous integration. By having sample te
 
 ## Unique features
 ### Using allowUnlimitedContractSize
-We allow our initial contract designs not to be limited by any contract size constraints with the use of the flag *allowUnlimitedContractSize*. Ganache has a default gas limit of 6,721,975 which does not reflect the actual gas limit of public testnet and mainnets, being 7,000,000 and 8,000,000 respectively. While our team does want to reduce the gas footprint while developing and iterating through different token designs/debugging, it’s been helpful not to be limited by a strict gas price or gas limit with testing. For example, we use longer descriptive messages in revert reasons when developing, but reduce them to be more succinct for final code versions. Reducing the string lengths saved us 3,000,000 gas. 
+We allow our initial contract designs not to be limited by any contract size constraints with the use of the flag *allowUnlimitedContractSize*. Ganache has a default gas limit of 6,721,975 which does not reflect the actual gas limit of public testnet and mainnets, being 7,000,000 and 8,000,000 respectively. While our team does want to reduce the gas footprint while developing and iterating through different token designs/debugging, it’s been helpful not to be limited by a strict gas price or gas limit with testing. For example, we use longer descriptive messages in revert reasons when developing, but reduce them to be more succinct for final code versions. Reducing the string lengths saved us 3,000,000 gas.
 
 
 Run each line in a different terminal window
@@ -65,7 +57,7 @@ After settling on a design, we’ll start iterating to reduce gas usage. As ment
 
 There are two custom utilities files that we have created and keep available for the right circumstance of contracts. First, we have a custom migration utilities script. Truffle has deployed contract management but only stores a single address for each contract deploy per network id; each deployed contract is treated as a singleton. However, there have been cases where we’ve deployed multiple instances of the same contract and have needed to save each of the deployed contract addresses. Our solution was to create a custom migration_utils.js that stored the contract addresses per migration in  a JSON file. From there, integration tests and accessory scripts use the contract addresses while still relying on the build directory for ABIs.
 
-The second script is related to testing time sensitive smart contracts. We’ve written a post about it called [Standing the Time of Test](https://medium.com/fluidity/standing-the-time-of-test-b906fcc374a9) and we’ve used this script and features in Ganache to run both idempotent tests as well as run simulations. 
+The second script is related to testing time sensitive smart contracts. We’ve written a post about it called [Standing the Time of Test](https://medium.com/fluidity/standing-the-time-of-test-b906fcc374a9) and we’ve used this script and features in Ganache to run both idempotent tests as well as run simulations.
 
 Running the command for a specific date
 
@@ -77,7 +69,7 @@ yarn ganache-unlimited --time '2019-02-15T15:53:00+00:00'
 
 Most of the features are in the [README](https://github.com/airswap/fluidity-truffle-box) in the directory and I’d love to take any questions or issues using this repository. Linking all these tools allows for a solid, sane development process for our team. They’re always at our fingertips with fluidity-truffle-box. Hopefully, you’ll be able to use the Fluidity Truffle Box to enhance your own smart contract development process!
 
-## Github repos 
+## Github repos
 * Fluidity Truffle Box: [https://github.com/fluidity/fluidity-truffle-box](https://github.com/fluidity/fluidity-truffle-box)
 * Gnosis-Mock: [https://github.com/gnosis/mock-contract](https://github.com/gnosis/mock-contract)
 * Truffle Assertions: [https://github.com/rkalis/truffle-assertions](https://github.com/rkalis/truffle-assertions)
@@ -95,12 +87,4 @@ Most of the features are in the [README](https://github.com/airswap/fluidity-tru
 * YouTube: [https://youtube.com/c/fluidityio](https://youtube.com/c/fluidityio)
 * Blog: [https://medium.com/fluidity](https://medium.com/fluidity)
 
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Join Deepa along with 60+ speakers from EY,  IBM, Quorum, Runtime Verification, and more!
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
 

--- a/src/blog/drizzle-vue-a-truffle-story.md
+++ b/src/blog/drizzle-vue-a-truffle-story.md
@@ -1,16 +1,8 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](/trufflecon2019)** is happening August 2-4 on Microsoft's campus in Redmond, WA. This year's event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that's on our minds. We hope you enjoy and we'll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 ![Drizzle + Vue = <3](/img/blog/drizzle-vue-a-truffle-story/title-image.png)
 
 Truffle is an organization that maintains a balance of transparency, mentorship, encouragement, inclusivity and humor that I'm thankful for everyday. While much could be written about Truffle's management culture, I want to share my experience of working on a side project here.
 
-Our remote work setup and the openness of our team contributes to a healthy and productive environment. The ability to schedule zoom sessions to brainstorm and discuss ideas fits well with our schedule. Every member contributes to this culture being generous with their time and knowledge. I'm happy and inspired to see team members grow as developers through the subtle mentorship as a result of our culture. 
+Our remote work setup and the openness of our team contributes to a healthy and productive environment. The ability to schedule zoom sessions to brainstorm and discuss ideas fits well with our schedule. Every member contributes to this culture being generous with their time and knowledge. I'm happy and inspired to see team members grow as developers through the subtle mentorship as a result of our culture.
 
 For most of my career, I dreaded mandatory soul draining review type meetings, but at Truffle, I look forward to the incredibly productive and creative weekly one-on-ones I have with Joshua Quintal, our Product Lead. Josh originally developed Drizzle and we often discuss its role in the dapp ecosystem, issues and roadmap during our meetings.
 
@@ -24,7 +16,7 @@ Drizzle originated as a helper library for a React project Josh was developing. 
 
 Unfortunately, this is not how Drizzle is understood by developers we interviewed formally and informally. The most common misunderstanding is that Drizzle is coupled with React, the most popular JavaScript front end framework. We can't blame our community as most of our documentation focuses on implementing Dapps using React.
 
-Drizzle was initially released with bindings only for React which created this misperception that excluded developers from utilizing other front end frameworks such as Vue and Angular. 
+Drizzle was initially released with bindings only for React which created this misperception that excluded developers from utilizing other front end frameworks such as Vue and Angular.
 
 The problem is that we didn't offer an easy solution for Vue or Angular and our documentation doesn't offer guidance. We want to change this! We want to support all the frameworks!
 
@@ -34,7 +26,7 @@ I felt this was an important problem to solve in order to improve the dapp devel
 
 The basic plan was to:
 - Use Vuex, Vue's popular State management plugin
-- Transform Drizzle's redux store to be consumed by Vuex 
+- Transform Drizzle's redux store to be consumed by Vuex
   - A redux store as an [2] [Observable](https://redux.js.org/api/store#subscribe) which would allow us to transform/map drizzle state to a more state pieces that Vuex could consume.
   - This would allow us to have more efficient UI renders by using RxJS techniques like `distinctUntilChanged`
 - Create basic Vue components mimicking drizzle-react-components
@@ -70,11 +62,3 @@ Come meet the team and learn about our tools at TruffleCon. We're looking forwar
 1. https://www.youtube.com/watch?v=XaVEZ1ucxac
 1. https://www.youtube.com/watch?v=ApJwXfWKl7Q
 1. https://www.youtube.com/watch?v=xyoztqeYd6U
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/ethereum-gas-exactimation.md
+++ b/src/blog/ethereum-gas-exactimation.md
@@ -161,7 +161,6 @@ Error: Returned error: VM Exception while processing transaction: revert
 
 Exactimation confirmed 🚀.
 
-#### For a deeper dive into gas exactimation, join us for [TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019?utm_source=medium&utm_medium=banner&utm_campaign=medium) August 2–4 at Microsoft’s campus in Redmond, WA! [Get Tickets](https://www.eventbrite.com/e/trufflecon-2019-blockchain-developer-conference-tickets-58020862963?aff=Medium&utm_source=medium&utm_medium=banner&utm_campaign=medium)
 
 Note: Since the initial release of gas exactimation, an even more performant iteration of the algorithm is currently in review here.
 

--- a/src/blog/how-ethical-advertising-will-transform-the-blockchain-industry.md
+++ b/src/blog/how-ethical-advertising-will-transform-the-blockchain-industry.md
@@ -1,17 +1,9 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 ![GitCoin](/img/blog/how-ethical-advertising-will-transform-the-blockchain-industry/pasted image 0-5.png)
 
 *CodeFund is an ethical ad platform that funds contributors to the open source ecosystem. Visit [CodeFund](https://codefund.io/) to learn more and apply.*
 
 ### The Conflicting Relationship Between Blockchain and Marketing
-In the initial years following Bitcoin’s inception, most blockchain companies didn’t need paid advertising. The early adopters were a community of cypherpunks, libertarians, developers, miners, and hobbyists, that truly believed in the power of decentralized networks. To them, adoption was inevitable, and rather than putting paid ads in front of the general public, resources were better spent building wallets, development tools, infrastructure, and scalability solutions. 
+In the initial years following Bitcoin’s inception, most blockchain companies didn’t need paid advertising. The early adopters were a community of cypherpunks, libertarians, developers, miners, and hobbyists, that truly believed in the power of decentralized networks. To them, adoption was inevitable, and rather than putting paid ads in front of the general public, resources were better spent building wallets, development tools, infrastructure, and scalability solutions.
 
 Additionally, almost all early blockchain users and entrepreneurs were extremely privacy-conscious. Pseudonymity is a key component to cryptocurrencies, they wouldn’t work in a permissionless manner without it. The Adtech industry, on the other hand, is run by monolithic centralized powerhouses that gather and store immense amounts of personal data for precise targeting. For the first 5 years of Bitcoin, **the blockchain community ethos was quite literally the polar opposite of the advertising industry**.
 
@@ -76,12 +68,3 @@ The first option is working with companies to run direct advertising campaigns. 
 At Gitcoin and CodeFund, we are a small team that has been in the blockchain world for years. We view every publisher and advertiser as a partner, diligently vet them, and hold them to the highest standards. **We’d like to see ethical advertising become the new standard in the blockchain space, and eventually on the Internet as a whole.**
 
 If your blockchain company is interested in advertising to a high-quality audience, or you would like to earn passive income showing relevant ads on your website without sacrificing your community’s privacy, CodeFund is for you! Apply now on the [CodeFund](https://codefund.io/) landing page and we’ll be in touch, or reach out to [connor@codefund.io](mailto:connor@codefund.io) for more information.
-
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/how-the-arrival-of-web-3-0-is-transforming-traditional-business-models.md
+++ b/src/blog/how-the-arrival-of-web-3-0-is-transforming-traditional-business-models.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 Although the Internet continues to drive digital transformation, the technology operates far beyond its original parameters. Since its inception over two decades ago, the web has been subject to increasing levels of centralization and mass surveillance. As a result, large corporations, governments, and media outlets remain the primary beneficiaries of an infrastructure meant to serve all of humanity. Herein lies the problem with the current Internet ecosystem, also known as Web 2.0.
 
 In the current online environment, users continually function as commodities, generating value along with their data. And while large entities should not shoulder the blame for their role in our everyday lives, their control over our personal information is cause for concern. As Internet founder Tim Berners-Lee [once said](https://www.vanityfair.com/news/2018/07/the-man-who-created-the-world-wide-web-has-some-regrets), "for people who want to make sure the Web serves humanity, we have to concern ourselves with what people are building on top of it."
@@ -99,12 +91,3 @@ State channels are mostly two-way pathways open between two users that want to c
 As the development of Web 3.0 technology persists, blockchain technology will remain a vital component of online infrastructure. Although the world continues to benefit from the transformative power of the web, user empowerment remains a priority among a growing segment of society. In a time when centralized institutions and governments exert control over personal data, many have begun to challenge the status quo.
 
 Those exploring this emerging subset of the web are well-positioned to benefit from growing momentum. By leveraging Web 3.0 technologies, companies also have the ability to enact new, potentially lucrative business models. Regardless of the industry, the new web presents an opportunity to pivot from traditional revenue streams in search of more optimal solutions. In the midst of ongoing innovation, it’s important to note that all new technology requires refinement - and Web 3.0 is only just beginning.
-
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Join Kevin along with 60+ speakers from EY, IBM, Quorum, Runtime Verification, and more!
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/introducing-truffle-db-part-1.md
+++ b/src/blog/introducing-truffle-db-part-1.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 ## Introducing Truffle DB, part 1: Artifact archeology
 Truffle is not a small utility: it compiles your contracts, deploys them to multiple networks, runs your automated tests, provides an interactive debugger for when things go wrong, offers a library for interacting with your contracts on the frontend, … (*the list goes on.*) With just over 20,000 lines of code and close to thirty discrete software packages, Truffle has a lot going on.
 
@@ -29,7 +21,7 @@ For starters: artifact files are huge! Too huge! In addition to Truffle reading 
   *for the curious: the AST is the reason your code works whether you wrote it all on a single line or not. Source gets parsed, and the AST is the result. Truffle and other tools rely on the AST for things like debugging, code coverage, and linting.</figcaption>
 </figure>
 
-By the byte, almost all of the information in each contract artifact is for internal use or for some specific purpose. **Only a small subset of the data in each artifact is necessary for your frontend or for you to think about directly.** Thus far, users who have struggled with these large files needed to use a tool like [jq](https://stedolan.github.io/jq/) or write a custom solution. 
+By the byte, almost all of the information in each contract artifact is for internal use or for some specific purpose. **Only a small subset of the data in each artifact is necessary for your frontend or for you to think about directly.** Thus far, users who have struggled with these large files needed to use a tool like [jq](https://stedolan.github.io/jq/) or write a custom solution.
 
 In addition to these files being too large, the information is grouped purely by the idea of “contract name”. What if you want to have two contracts with the same name? You can’t. What if you want to debug an old version of your contract, deployed to a testnet? I hope you backed up your old artifacts directory somehow.
 
@@ -55,11 +47,3 @@ We’ll get into it more in the next post, but Truffle DB aims to provide two th
 
 In doing this, we’re taking a data-first approach, organizing your project’s information through immutable records and a clean separation of concerns. Stay tuned for the next post, where we’ll talk about this more and outline our release plan for Truffle DB: what we’ll be releasing first, what work still needs to be done, and how we plan to handle backwards compatibility over time.
 
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/introducing-truffle-db-part-2.md
+++ b/src/blog/introducing-truffle-db-part-2.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 Welcome back! If you missed the [first part](/blog/introducing-truffle-db-part-1) of this post, you may want to read it to learn more about Truffle’s contract artifacts, their current limitations, and why we seek to build a better solution.
 
 Or, just to catch up:
@@ -37,7 +29,7 @@ Truffle DB comprises two key ideas, currently at different stages of development
   <figcaption>**Data model excerpt**: how contracts, sources, compilers, and compilations all relate. ([Text-accessible version](https://github.com/trufflesuite/artifact-updates/blob/master/docs/uml/macros.iuml) available via diagram source)</figcaption>
 </figure>
 
-What is a smart contract? What is your contract’s bytecode, what is its source code, and how do they relate? By looking at how Truffle expects these relationships in practice, and considering how these concepts are commonly understood, we hope to make life easy by creating a shared vocabulary for interacting with the smart contract domain. 
+What is a smart contract? What is your contract’s bytecode, what is its source code, and how do they relate? By looking at how Truffle expects these relationships in practice, and considering how these concepts are commonly understood, we hope to make life easy by creating a shared vocabulary for interacting with the smart contract domain.
 
 Diagrams are worth more than words here, so please check out our data model docs to get a broader sense for what this represents.
 
@@ -110,11 +102,3 @@ Please reach out with questions/thoughts/use case ideas/implementation strategie
 We’re tracking overall progress in this [GitHub issue (trufflesuite/truffle#1718)](https://github.com/trufflesuite/truffle/issues/1718). Expect to see this filled out more in the coming weeks, so please follow along there if you’re interested.
 
 Thanks for reading! Hope to see you at TruffleCon!
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/open-call-for-contributions-truffle-pegasys-eea-private-transactions.md
+++ b/src/blog/open-call-for-contributions-truffle-pegasys-eea-private-transactions.md
@@ -1,10 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](/trufflecon2019)** is happening August 2-4 on Microsoft's campus in Redmond, WA. This year's event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that's on our minds. We hope you enjoy and we'll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
 
 # Open call for contributions by Truffle + PegaSys: EEA private transactions
 ![Pegasys Truffle Open Call For Contributions](https://i.imgur.com/GLw8iok.jpg)
@@ -101,10 +94,3 @@ Two things:
 
 For more information or help on this contribution, contact [Felipe](mailto:felipe.faraggi@consensys.net) from [PegaSys](http://pegasys.tech),  or write us on [our gitter channel](https://gitter.im/PegaSysEng/pantheon).
 
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/the-best-things-to-do-in-seattle-during-trufflecon.md
+++ b/src/blog/the-best-things-to-do-in-seattle-during-trufflecon.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 ![river view at Marymoor Park](/img/blog/the-best-things-to-do-in-seattle-during-trufflecon/layer-1.jpg)
 
 ## [Marymoor Park](https://www.kingcounty.gov/services/parks-recreation/parks/parks-and-natural-lands/popular-parks/marymoor.aspx)
@@ -14,11 +6,11 @@ Marymoor Park, located on the north end of Lake Sammamish in Redmond, Washington
 
 ## [Sammamish River Trail](https://www.alltrails.com/trail/us/washington/sammamish-river)
 
-The Sammamish River Trail is a beautiful 19-mile bike path and recreational trail in King County, Washington that runs along the Sammamish River from Blythe Park in Bothell to Marymoor Park in Redmond. There are several places along the trail you can enter. It's perfect for biking, running, or just enjoying a nice walk in the beautiful outdoors! 
+The Sammamish River Trail is a beautiful 19-mile bike path and recreational trail in King County, Washington that runs along the Sammamish River from Blythe Park in Bothell to Marymoor Park in Redmond. There are several places along the trail you can enter. It's perfect for biking, running, or just enjoying a nice walk in the beautiful outdoors!
 
 ## [Idylwood Beach Park](https://experienceredmond.com/activities-and-attractions/idylwood-beach-park/)
 
-August can reach temperatures of up to 80 degrees, which is quite hot for Seattleites. Idylwood Beach Park is one of the best places to cool off. It's a waterfront park on Lake Sammamish with a beach, boat ramp, playground & canoe rentals. 
+August can reach temperatures of up to 80 degrees, which is quite hot for Seattleites. Idylwood Beach Park is one of the best places to cool off. It's a waterfront park on Lake Sammamish with a beach, boat ramp, playground & canoe rentals.
 
 ## [Microsoft Visitor Center](https://experienceredmond.com/activities-and-attractions/microsoft-visitors-center/)
 
@@ -33,10 +25,10 @@ Nestled in the beautiful Sammamish River Valley just 30 minutes northeast of Sea
 From the historic and beautiful grounds of Chateau Ste. Michelle to the quaint boutique wineries where you are likely to have the winemaker themselves pour you a glass of his or her finest blend, a wonderful variety of wine tasting experiences awaits you!
 
 ![winery building in the Sammamish River Valley](/img/blog/the-best-things-to-do-in-seattle-during-trufflecon/layer-3.jpg)
- 
+
 ## [Black Raven Brewing Company](http://www.blackravenbrewing.com/)
 
-Black Raven is a neighborhood brewery with a friendly retail taproom, The Raven's Nest, with locations in both Redmond and Woodinville. The Raven's Nest is not a traditional brewpub; it's more like our brewery's living room. Open 7 days a week and a seating capacity of about 100, it's home to local beer lovers who want to be a part of a community that enjoy great beer and great friends. 
+Black Raven is a neighborhood brewery with a friendly retail taproom, The Raven's Nest, with locations in both Redmond and Woodinville. The Raven's Nest is not a traditional brewpub; it's more like our brewery's living room. Open 7 days a week and a seating capacity of about 100, it's home to local beer lovers who want to be a part of a community that enjoy great beer and great friends.
 
 ## [Mac & Jack's Brewing](https://www.macandjacks.com/)
 
@@ -77,15 +69,8 @@ People will protect the places they love to hike. WTA rallies hikers to raise ou
 ![beautful views of the mountains on the hiking trail](/img/blog/the-best-things-to-do-in-seattle-during-trufflecon/layer-8.jpg)
 
 ## [Mountain Biking](https://seattlemountainbiketours.com/)
- 
+
 Your all-inclusive mountain biking tour in Seattle includes pickup from Downtown Seattle or Bellevue and shuttle transportation to our favorite trails for intermediate and experienced cyclists. At the trailhead, you get your high-quality mountain bike, a helmet, gloves, and any other safety gear needed for our ride. Don't worry, we have plenty of water and snacks for our mountain biking adventure!
 
 ![mountain biker rounding the bend in Seattle](/img/blog/the-best-things-to-do-in-seattle-during-trufflecon/layer-9.jpg)
 
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/the-best-ways-to-contribute-to-truffle.md
+++ b/src/blog/the-best-ways-to-contribute-to-truffle.md
@@ -1,29 +1,21 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
+Have you ever thought about contributing to Truffle? All of us at Truffle really enjoy producing free and open source software, and it is especially fun when many of you in the community contribute. User contributions make life easier for us, make our work more enjoyable by showing that you’re engaged, and often give us a chance to learn from those that offer code to the project. We’d absolutely love any and all developers to contribute to our project. The following are a few ways that you can get involved.
 
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
+## Read the contributor guidelines.
 
-Have you ever thought about contributing to Truffle? All of us at Truffle really enjoy producing free and open source software, and it is especially fun when many of you in the community contribute. User contributions make life easier for us, make our work more enjoyable by showing that you’re engaged, and often give us a chance to learn from those that offer code to the project. We’d absolutely love any and all developers to contribute to our project. The following are a few ways that you can get involved. 
+The first step anyone should take before contributing to Truffle is to hop on over to our Github page and [read our contributing guidelines](https://github.com/trufflesuite/truffle/blob/develop/CONTRIBUTING.md). Our contributing guidelines will give you a baseline understanding of how Truffle is built, which tools to use during development, and other useful information to get you started. Make sure to read those guidelines before continuing on in this post.
 
-## Read the contributor guidelines. 
-
-The first step anyone should take before contributing to Truffle is to hop on over to our Github page and [read our contributing guidelines](https://github.com/trufflesuite/truffle/blob/develop/CONTRIBUTING.md). Our contributing guidelines will give you a baseline understanding of how Truffle is built, which tools to use during development, and other useful information to get you started. Make sure to read those guidelines before continuing on in this post. 
-
-## Follow the command flow. 
+## Follow the command flow.
 
 You’ll see that the contributing guidelines focus on the command flow. This is because at its core, Truffle is a command line tool that processes and runs specific commands on behalf of a user. If you can figure out where a command starts, you can follow its execution to get a better understanding of what Truffle is doing. We recommend choosing your favorite command and following its path through the code. We’d also recommend performing your own local experiments by changing the behavior of a specific command and seeing how it behaves. Don’t forget to read the contributing guidelines above, as it tells you where to get started for each command.
 
-## Change callbacks to Promises. 
+## Change callbacks to Promises.
 
 Given the lifetime of the project -- over four years! -- Truffle has its share of legacy code. Before Promises became widespread in the Node world, callbacks were used to control the flow of asynchronous code within Truffle. The code was written in a style where a callback function was passed from one method to the next, intended to be executed after everything else had finished running or when an error occurred. Nowadays, many people find this style of code to be abstruse, and hard to understand, and now favor Promises over callbacks. We do too. One of our major tasks over the coming year is to rework our code to favor a Promise-based coding style instead of a callback-based one. We are always interested in receiving PRs that clean up our callbacks and make the code easier to understand for everyone (we love you async/await).
 
 
-## Start small, and chat with us for larger tasks. 
+## Start small, and chat with us for larger tasks.
 
-It can be very overwhelming to begin contributing to Truffle with a big feature. Instead, we recommend going after a smaller, more bite-sized change that will not only make you feel more successful, but can also help you get a better understanding of the underlying code. If you find something trivial, like a documentation error, go ahead and fork the repository, make your changes, and submit a pull request. For something bigger, we like to have a discussion first as our tools support many different use cases and platforms. If you have a great idea for a change that will require significant effort, we recommend filing a GitHub issue with a proposal or contacting us using the channels below. We can layout specs, bounce ideas around, and agree on what’s needed before you dive in. 
+It can be very overwhelming to begin contributing to Truffle with a big feature. Instead, we recommend going after a smaller, more bite-sized change that will not only make you feel more successful, but can also help you get a better understanding of the underlying code. If you find something trivial, like a documentation error, go ahead and fork the repository, make your changes, and submit a pull request. For something bigger, we like to have a discussion first as our tools support many different use cases and platforms. If you have a great idea for a change that will require significant effort, we recommend filing a GitHub issue with a proposal or contacting us using the channels below. We can layout specs, bounce ideas around, and agree on what’s needed before you dive in.
 
 ## Tackle an issue.
 
@@ -32,11 +24,3 @@ Many of our users submit issues for things that need to be fixed. Sometimes thes
 ## Contact us.
 
 As always, we’d love to hear your feedback and concerns, as well as answer any questions you have when contributing to Truffle. Feel free to reach out to us on our [Spectrum](https://spectrum.chat/trufflesuite) page, or file an issue on [Github](https://github.com/trufflesuite/truffle/issues). We'd love to hear from you. Happy Truffling!
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/the-blockchain-problem-that-ens-solves.md
+++ b/src/blog/the-blockchain-problem-that-ens-solves.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 The blockchain world has a UI problem. This is what an Ethereum receiving address looks like:
 
 **0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359**
@@ -24,7 +16,7 @@ ENS launched in 2017 with the native TLD.ETH, but we’ve been experimenting wit
 
 We want to make it as easy as possible for dapp developers to take advantage of the big UI gains that ENS provides, which is why we’re working with Truffle. We are excited to be announcing several useful ENS integrations built into TruffleSuite at TruffleCon, so stay tuned!
 
-[Register your domain name](https://ens.domains/) using ENS today! 
+[Register your domain name](https://ens.domains/) using ENS today!
 
 Helpful Links:
 * Website: [https://ens.domains/](https://ens.domains/)
@@ -33,10 +25,3 @@ Helpful Links:
 * Gitter: [https://gitter.im/ethereum/go-ethereum/name-registry](https://gitter.im/ethereum/go-ethereum/name-registry)
 * Forum: [https://discuss.ens.domains/](https://discuss.ens.domains/)
 
-<div class="post-trufflecon-box mt-5 text-center">
-  Join Brantly and 60+ other speakers from Microsoft, RSK, Quorum, GitCoin, Security Innovation, Trail of Bits, Core Scientific, and more!
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/token-taxonomy-framework.md
+++ b/src/blog/token-taxonomy-framework.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](/trufflecon2019)** is happening August 2-4 on Microsoft's campus in Redmond, WA. This year's event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that's on our minds. We hope you enjoy and we'll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 To some, the sudden rise of Tokens in the blockchain dialog comes as a surprise. However, tokens have always been the bedrock of the blockchain movement. The introduction of SmartContract by Ethereum quickly overshadowed them, particularly in enterprise contexts. The capabilities of Smart Contracts and the broad acceptance of them, thanks to companies like Truffle, blazed a trail forward and we all went along. It wasn’t until we got halfway up the trail that someone turned around and asked, “did we pack any trail mix?”
 
 Sure, we had Ether, but one cannot persist on Ether alone. Focus shifted back to our roots. Developers who had steeped in SmartContracts turned their attention to tokens. However, they also brought a bit of baggage. You can do a lot in a Token using SmartContract concepts. We started to see the blurring of lines between what a contract was and what was a token, leading to a good bit of confusion all around.
@@ -15,11 +7,3 @@ Back in April, [the Token Taxonomy Initiative (TTI)](https://tokentaxonomy.org/)
 ![Token Taxonomy Framework](/img/blog/token-taxonomy-framework/framework.png)
 
 I’ll be presenting an [Introduction to the TTF](https://trufflecon2019.sched.com/event/RneW/token-taxonomy-framework) at TruffleCon on August 4th here in Redmond, WA. Swing by to hear how you can use the TTF to communicate with customers and partners, use the same terms and get solid requirements from the business, legal and regulatory communities.
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Join Marley along with 60+ speakers at TruffleCon 2019 in Redmond, WA August 2-4!
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/upcoming-improvements-to-encoding-and-decoding.md
+++ b/src/blog/upcoming-improvements-to-encoding-and-decoding.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](/trufflecon2019)** is happening August 2-4 on Microsoft's campus in Redmond, WA. This year's event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that's on our minds. We hope you enjoy and we'll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 When you’re writing, running, or debugging your smart contract, you don’t want to have to deal with raw binary data. Truffle––and Ganache and Drizzle––already contain a number of encoding and decoding features to help you interact with your contract and understand what you’re seeing. But luckily, encoding and decoding are about to become even more robust, informative, and usable.
 
 Not all of these features will be immediately available in Truffle 5.1, but some will, so let’s start with one that will be ready! Allow me to illustrate:
@@ -26,10 +18,3 @@ Finally, I’d like to discuss decoding of events. Currently, when you check wha
 
 We’re hoping Truffle’s new encoder and decoder will make staring at raw binary data a thing of the past! Unless you like to, of course. But for those of you who’d prefer to take a higher-level view and deal directly with what that binary data actually means… well, that’s what Truffle’s for, isn’t it?
 
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>

--- a/src/blog/why-i-love-trufflecon.md
+++ b/src/blog/why-i-love-trufflecon.md
@@ -1,11 +1,3 @@
-<div class="post-trufflecon-box mb-5">
-  **[TruffleCon 2019](https://www.trufflesuite.com/trufflecon2019)** is happening August 2-4 on Microsoft’s campus in Redmond, WA. This year’s event will include 60+ speakers from the blockchain ecosystem, along with hands-on workshops geared toward novice users and expert builders alike. The Truffle team is ramping up for TruffleCon 2019 by writing a daily blog post about everything that’s on our minds. We hope you enjoy and we’ll see you in Redmond!
-
-  <div class="text-center">
-    <a class="btn btn-truffle mt-3" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>
-
 **By Josh Quintal, Head of Product & Marketing**
 
 The blockchain space is hitting a plateau.
@@ -20,7 +12,7 @@ This year we have over 60 speakers across 60 sessions including: Thomas Hodges o
 
 TruffleCon is a conference, sure, but it's more than that: it's the feeling of excitement when learning a new technology; the eureka we felt when first discovering this new frontier. It's connections made in minutes that can last a lifetime.
 
-It's the culmination of everything we've worked for since the founding of this company. 
+It's the culmination of everything we've worked for since the founding of this company.
 
 I hope to not only see you there but to have a chat about what we do well and how we can improve (you'll also get a hat). Together we're building the community that will take us from this plateau onward to the next meteoric growth spurt.
 
@@ -31,11 +23,3 @@ Sincerely,
 </p>
 
 Josh Quintal
-
-<div class="post-trufflecon-box mt-5 text-center">
-  Get your ticket for TruffleCon 2019 Today
-
-  <div class="mt-3">
-    <a class="btn btn-truffle" href="/trufflecon2019">Get your Ticket for TruffleCon 2019 Today</a>
-  </div>
-</div>


### PR DESCRIPTION
This PR removes the Trufflecon header/footer adverts from our 30 day blog post run. The content stands even though the advert aged. Feedback appreciated.