### PR TITLE
Minor typo correction and documentation update.

### DIFF
--- a/src/docs/truffle/quickstart.md
+++ b/src/docs/truffle/quickstart.md
@@ -285,7 +285,7 @@ The only extra step, aside from running Ganache, is that it requires editing the
 
 1. Download and install [Ganache](/ganache).
 
-1. Open `truffle.js` in a text editor. Replace the content with the following:
+1. Open `truffle-config.js` or `truffle.js` in a text editor. Replace the content with the following:
 
    ```javascript
    module.exports = {

--- a/src/docs/truffle/quickstart.md
+++ b/src/docs/truffle/quickstart.md
@@ -80,7 +80,7 @@ Once this operation is completed, you'll now have a project structure with the f
 1. On a terminal, run the Solidity test:
 
    ```shell
-   truffle test ./test/TestMetacoin.sol
+   truffle test ./test/TestMetaCoin.sol
    ```
 
    You will see the following output

--- a/src/docs/truffle/quickstart.md
+++ b/src/docs/truffle/quickstart.md
@@ -285,7 +285,7 @@ The only extra step, aside from running Ganache, is that it requires editing the
 
 1. Download and install [Ganache](/ganache).
 
-1. Open `truffle-config.js` or `truffle.js` in a text editor. Replace the content with the following:
+1. Open `truffle-config.js` in a text editor. Replace the content with the following:
 
    ```javascript
    module.exports = {


### PR DESCRIPTION
Hi,

If you follow the Truffle Quickstart using a freshly unboxed MetaCoin...

1. **Changed**: `truffle test ./test/TestMetacoin.sol` to `truffle test ./test/TestMetaCoin.sol`
1. **Changed**: "Open `truffle.js`" to "Open `truffle-config.js` or `truffle.js`"

Pushed this under fix/* because I'm including a fix to a command but I supposed I could also have added it to content/*?