### PR TITLE
configure yarn locally to ignore engines

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+# ignore engines to give metalsmith a pass
+ignore-engines true

--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ Install `yarn` if you haven't already:
 npm install -g yarn
 ```
 
-You'll also need to ignore the engine check in yarn due to a [grossly outdated npm package](https://travis-ci.org/trufflesuite/trufflesuite.com/builds/607415891#L214). Optionally you can do `yarn --ignore-engines` during the install step.
-
-```
-yarn config set ignore-engines true
-```
-
 ## Getting Started
 Download zip file or git clone repo:
 
@@ -60,4 +54,4 @@ yarn build
 
 Navigate to ./build folder for the compiled files.
 
- 
+


### PR DESCRIPTION
This PR introduces a project/package scoped `.yarnrc` file to specify its yarn configuration