### PR TITLE
deleted drizzle and web3 from action obj to be dispatched when adding contracts dynamically

### DIFF
--- a/src/docs/drizzle/getting-started/contract-interaction.md
+++ b/src/docs/drizzle/getting-started/contract-interaction.md
@@ -92,7 +92,7 @@ You can also delete contracts using either `drizzle.deleteContract()` or the `DE
 const contractName = "MyContract"
 
 // Using an action
-dispatch({type: 'DELETE_CONTRACT', drizzle, contractName})
+dispatch({type: 'DELETE_CONTRACT', contractName})
 
 // Or using the Drizzle context object
 this.context.drizzle.deleteContract(contractName)

--- a/src/docs/drizzle/getting-started/contract-interaction.md
+++ b/src/docs/drizzle/getting-started/contract-interaction.md
@@ -78,7 +78,7 @@ var contractConfig = {
 events = ['Mint']
 
 // Using an action
-dispatch({type: 'ADD_CONTRACT', drizzle, contractConfig, events, web3})
+dispatch({type: 'ADD_CONTRACT', contractConfig, events})
 
 // Or using the Drizzle context object
 this.context.drizzle.addContract(contractConfig, events)


### PR DESCRIPTION
Drizzle and web3 were showing as required properties in the action object to be dispatched to add contracts dynamically, these are no longer required. 
{type: 'ADD_CONTRACT', contractConfig, events}, is all that is needed, and it is more symmetrical with the other methods shown below in line 84, using the Drizzle context object directly.