### PR TITLE
Add link to migrate command options

### DIFF
--- a/src/docs/truffle/getting-started/running-migrations.md
+++ b/src/docs/truffle/getting-started/running-migrations.md
@@ -14,7 +14,7 @@ To run your migrations, run the following:
 $ truffle migrate
 ```
 
-This will run all migrations located within your project's `migrations` directory. At their simplest, migrations are simply a set of managed deployment scripts. If your migrations were previously run successfully, `truffle migrate` will start execution from the last migration that was run, running only newly created migrations. If no new migrations exists, `truffle migrate` won't perform any action at all. You can use the `--reset` option to run all your migrations from the beginning. For local testing make sure to have a test blockchain such as [Ganache](/ganache) installed and running before executing `migrate`.
+This will run all migrations located within your project's `migrations` directory. At their simplest, migrations are simply a set of managed deployment scripts. If your migrations were previously run successfully, `truffle migrate` will start execution from the last migration that was run, running only newly created migrations. If no new migrations exists, `truffle migrate` won't perform any action at all. You can use the `--reset` option to run all your migrations from the beginning.  Other command options are documented [here](../reference/truffle-commands#migrate). For local testing make sure to have a test blockchain such as [Ganache](/ganache) installed and running before executing `migrate`.
 
 ## Migration files
 


### PR DESCRIPTION
This PR adds the sentence "Other command options are documented here" with a link to more easily find other command-line options for the `truffle migrate` command, from the documentation page focused on that command.

Note: I do not have the build setup right now to test the link and make sure it works.  I would recommend that some contributor do that before the PR is merged. 