### PR TITLE
updated for drizzle v1.5.1 with examples

### DIFF
--- a/src/docs/drizzle/react/react-integration.md
+++ b/src/docs/drizzle/react/react-integration.md
@@ -4,145 +4,158 @@ layout: docs.hbs
 ---
 # React Integration
 
-`drizzle-react` is the official way to integrate Drizzle with your React dapp.
+`@drizzle/react-plugin` is the official way to integrate Drizzle with your React dapp.
 
-Check out the [Drizzle Truffle Box](https://github.com/truffle-box/drizzle-box) for a complete example (also featuring `drizzle-react-components`), or continue reading to create your own setup.
+Check out the [Drizzle Truffle Box](https://github.com/truffle-box/drizzle-box) for a complete example or continue reading to create your own setup.
+
+Also, check out `@drizzle/react-components` for Drizzle's [prebuilt react components](https://github.com/trufflesuite/drizzle/tree/develop/packages/react-components).
 
 ## Installation
 
-Install Drizzle React Components via npm:
+Install Drizzle React-Plugin via npm:
 ```bash
-npm install --save drizzle-react
+npm install @drizzle/react-plugin
 ```
 
-**Note**: `drizzle-react` requires Requires React 0.14 or greater. You'll also need the `drizzle` package, if it isn't already installed.
+**Note**: `@drizzle/react-plugin` requires Requires React v16.3+ for the Context API. You'll also need the `@drizzle/store` package, if it isn't already installed.
 
 ## Getting Started
 
 **Note**: Since Drizzle uses web3 1.0 and web sockets, be sure your development environment can support these.
 
-1. Import the provider.
+1. Import the `DrizzleContext` provider.
    ```javascript
-   import { DrizzleProvider } from 'drizzle-react'
+   import { DrizzleContext } from '@drizzle/react-plugin'
    ```
 
-1. Create an `options` object and pass in the desired contract artifacts for Drizzle to instantiate. Other options are available, see [the Options section of the Drizzle docs](https://github.com/trufflesuite/drizzle#options) below.
+1. Create a `drizzleOptions` object and pass in the desired contract artifacts for Drizzle to instantiate. Other options are available, see [the Options section of the Drizzle docs](https://www.trufflesuite.com/docs/drizzle/reference/drizzle-options).
    ```javascript
    // Import contracts
    import SimpleStorage from './../build/contracts/SimpleStorage.json'
    import TutorialToken from './../build/contracts/TutorialToken.json'
 
-   const options = {
+   const drizzleOptions = {
      contracts: [
        SimpleStorage,
        TutorialToken
-     ]
+     ],
+     events: {
+       SimpleStorage: ["StorageSet"],
+     },
    }
    ```
 
-1. Wrap your app with `DrizzleProvider` and pass in an `options` object.
-   ```javascript
-   <DrizzleProvider options={options}>
-     <App />
-   </DrizzleProvider>
-   ```
+1. Import `Drizzle` and `generateStore`.
+    ```javascript
+    import { Drizzle, generateStore } from "@drizzle/store";
+    ```
 
-1. Wrap your components using the `drizzleConnect` function. It has the same API as the `connect()` function in `react-redux`. [See their docs here](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options).
-   ```javascript
-   import { drizzleConnect } from 'drizzle-react'
+1. Create a new `drizzle` instance with the `drizzleOptions` object and the generated store.
+    ```javascript
+    const drizzleStore = generateStore(drizzleOptions);
+    const drizzle = new Drizzle(drizzleOptions, drizzleStore)
+    ```
 
-   const mapStateToProps = state => {
-     return {
-       drizzleStatus: state.drizzleStatus,
-       SimpleStorage: state.contracts.SimpleStorage
-     }
-   }
+1. Pass the `drizzle` object to the `DrizzleContext.Provider` component.
+    ```javascript
+    <DrizzleContext.Provider drizzle={drizzle}>
+    </DrizzleContext.Provider>
+    ```
 
-   const HomeContainer = drizzleConnect(Home, mapStateToProps);
-   ```
-   See [Drizzle State in the Drizzle docs](https://github.com/trufflesuite/drizzle#drizzle-state) for the entire state tree.
+1. Use `DrizzleContext.Consumer` to consume the drizzle context and pass `drizzle` and `drizzleState` to your component. Drizzle also provides prebuilt components via the `@drizzle/react-components`.
 
-1. Get contract data by accessing the contracts via `context`. Calling the `data()` function on a contract will first check the store for a cached result. If empty, Drizzle will query the blockchain and cache the response for future use. For more information on how this works, see [How Data Stays Fresh in the Drizzle docs](https://github.com/trufflesuite/drizzle#how-data-stays-fresh).
+    **Note**: We have to check that Drizzle is initialized before fetching data. The `initialized` variable returns the drizzle store's initialization status.
 
-   **Note:** We have to check that Drizzle is initialized before fetching data. A one-liner such as below is fine for display a few pieces of data, but a better approach for larger dapps is to use a [loading component](#recipe-loading-component).
-   ```javascript
-   // For convenience
-   constructor(props, context) {
-     super(props)
+    ```javascript
+    <DrizzleContext.Provider drizzle={drizzle}>
+            <DrizzleContext.Consumer>
+              {drizzleContext => {
+                const {drizzle, drizzleState, initialized} = drizzleContext;
 
-     this.contracts = context.drizzle.contracts
-   }
+                if(!initialized) {
+                  return "Loading..."
+                }
 
-   // If Drizzle is initialized (and therefore web3, accounts and contracts), fetch data.
-   // This will update automatically when the contract state is altered.
-   var storedData = this.props.drizzleStatus.initialized ? this.contracts.SimpleStorage.methods.storedData.data() : 'Loading...'
-   ```
+                return (
+                  <MyComponent drizzle={drizzle} drizzleState={drizzleState} />
+                  )
+                }}
+            </DrizzleContext.Consumer>
+          </DrizzleContext.Provider>
+    ``` 
+1. Fetch contract data by accessing contracts via `drizzle` and `drizzleState` in `props`. For more information on how this works, see [How Data Stays Fresh in the Drizzle docs](https://github.com/trufflesuite/drizzle#how-data-stays-fresh). For more info on the drizzle state, see [state tree docs.](https://github.com/trufflesuite/drizzle/tree/develop/packages/store#drizzle-state)
 
-   The contract instance has all of its standard web3 properties and methods. For example, sending a transaction is done as normal:
-   ```javascript
-   this.contracts.SimpleStorage.methods.set(this.state.storageAmount).send()
-   ```
+    The example below utilizes drizzle's `cacheCall` feature, which caches and synchronizes the call with the store. For more information on `cacheCall` and also `cacheSend`, see [Contract Interaction](https://www.trufflesuite.com/docs/drizzle/getting-started/contract-interaction).
+    ```javascript
+    // sample component
+    import React from 'react';
 
-## Recipe: Loading Component
+    class CacheCallExample extends React.Component {
+        state = { dataKey: null }
 
-The following wrapper and component will detect when your dapp isn't ready and allow you to display the appropriate status or course of action:
+        componentDidMount() {
+            const { drizzle } = this.props;
+            const contract = drizzle.contracts.SimpleStorage;
+            let dataKey = contract.methods["storedData"].cacheCall(); // declare this call to be cached and synchronized
+            this.setState({ dataKey })
+        }
 
-`LoadingContainer.js`
-
-```javascript
-import Loading from './Loading.js'
-import { drizzleConnect } from 'drizzle-react'
-
-// May still need this even with data function to refresh component on updates for this contract.
-const mapStateToProps = state => {
-  return {
-    drizzleStatus: state.drizzleStatus,
-    web3: state.web3
-  }
-}
-
-const LoadingContainer = drizzleConnect(Loading, mapStateToProps);
-
-export default LoadingContainer
-```
-
-`Loading.js`
-
-```javascript
-import React, { Component, Children } from 'react'
-
-class Loading extends Component {
-  constructor(props, context) {
-    super(props)
-  }
-
-  render() {
-    if (this.props.web3.status === 'failed')
-    {
-      return(
-        // Display a web3 warning.
-        <main>
-          <h1>⚠️</h1>
-          <p>This browser has no connection to the Ethereum network. Please use the Chrome/FireFox extension MetaMask, or dedicated Ethereum browsers Mist or Parity.</p>
-        </main>
-      )
+        render() {
+            const { SimpleStorage } = this.props.drizzleState.contracts;
+            const displayData = SimpleStorage.storedData[this.state.dataKey] // if displayData (an object) exists, then we can display the value below
+            return (
+                <p>Hi from Truffle! Here is your storedData: {displayData && displayData.value}</p>
+            )
+        }
     }
 
-    if (this.props.drizzleStatus.initialized)
-    {
-      // Load the dapp.
-      return Children.only(this.props.children)
-    }
+    export default CacheCallExample
+    ```
+    **Note**: The contract instances have all the standard web3 properties and methods.
+    ```javascript
+    // sets SimpleStorage contract's storedData state variable to uint 5.
+    drizzle.contracts.SimpleStorage.methods.set(5).send();
+    ```
 
-    return(
-      // Display a loading indicator.
-      <main>
-        <h1>⚙️</h1>
-        <p>Loading dapp...</p>
-      </main>
-    )
+## Example Code Snippet
+```javascript
+// App.js
+import React from "react";
+import { DrizzleContext } from "@drizzle/react-plugin";
+import { Drizzle, generateStore } from "@drizzle/store";
+
+import SimpleStorage from "./contracts/SimpleStorage.json";
+import MyComponent from "./MyComponent"; // Check out drizzle's react components at @drizzle/react-components
+
+const drizzleOptions = {
+  contracts: [SimpleStorage],
+  events: {
+    SimpleStorage: ["StorageSet"],
+  },
+};
+
+const drizzleStore = generateStore(drizzleOptions);
+const drizzle = new Drizzle(drizzleOptions, drizzleStore)
+
+const App = () => {
+    return (
+      <DrizzleContext.Provider drizzle={drizzle}>
+        <DrizzleContext.Consumer>
+          {drizzleContext => {
+            const {drizzle, drizzleState, initialized} = drizzleContext;
+            
+            if(!initialized) {
+              return "Loading..."
+            }
+            
+            return (
+              <MyComponent drizzle={drizzle} drizzleState={drizzleState} />
+              )
+            }}
+        </DrizzleContext.Consumer>
+      </DrizzleContext.Provider>
+    );
   }
-}
 
-export default Loading
+export default App;
 ```

--- a/src/docs/drizzle/react/react-integration.md
+++ b/src/docs/drizzle/react/react-integration.md
@@ -24,105 +24,103 @@ npm install @drizzle/react-plugin
 **Note**: Since Drizzle uses web3 1.0 and web sockets, be sure your development environment can support these.
 
 1. Import the `DrizzleContext` provider.
-   ```javascript
-   import { DrizzleContext } from '@drizzle/react-plugin'
-   ```
+  ```javascript
+  import { DrizzleContext } from '@drizzle/react-plugin'
+  ```
 
 1. Create a `drizzleOptions` object and pass in the desired contract artifacts for Drizzle to instantiate. Other options are available, see [the Options section of the Drizzle docs](https://www.trufflesuite.com/docs/drizzle/reference/drizzle-options).
-   ```javascript
-   // Import contracts
-   import SimpleStorage from './../build/contracts/SimpleStorage.json'
-   import TutorialToken from './../build/contracts/TutorialToken.json'
+  ```javascript
+  // Import contracts
+  import SimpleStorage from './../build/contracts/SimpleStorage.json'
+  import TutorialToken from './../build/contracts/TutorialToken.json'
 
-   const drizzleOptions = {
-     contracts: [
-       SimpleStorage,
-       TutorialToken
-     ],
-     events: {
-       SimpleStorage: ["StorageSet"],
-     },
-   }
-   ```
+  const drizzleOptions = {
+    contracts: [
+      SimpleStorage,
+      TutorialToken
+    ],
+    events: {
+      SimpleStorage: ["StorageSet"],
+    },
+  }
+  ```
 
-1. Import `Drizzle` and `generateStore`.
-    ```javascript
-    import { Drizzle, generateStore } from "@drizzle/store";
-    ```
+1. Import `Drizzle`.
+  ```javascript
+  import { Drizzle } from "@drizzle/store";
+  ```
 
-1. Create a new `drizzle` instance with the `drizzleOptions` object and the generated store.
-    ```javascript
-    const drizzleStore = generateStore(drizzleOptions);
-    const drizzle = new Drizzle(drizzleOptions, drizzleStore)
-    ```
+1. Create a new `drizzle` instance with the `drizzleOptions` object.
+  ```javascript
+  const drizzle = new Drizzle(drizzleOptions);
+  ```
 
 1. Pass the `drizzle` object to the `DrizzleContext.Provider` component.
-    ```javascript
-    <DrizzleContext.Provider drizzle={drizzle}>
-    </DrizzleContext.Provider>
-    ```
+  ```javascript
+  <DrizzleContext.Provider drizzle={drizzle}></DrizzleContext.Provider>
+  ```
 
 1. Use `DrizzleContext.Consumer` to consume the drizzle context and pass `drizzle` and `drizzleState` to your component. Drizzle also provides prebuilt components via the `@drizzle/react-components`.
 
-    **Note**: We have to check that Drizzle is initialized before fetching data. The `initialized` variable returns the drizzle store's initialization status.
+  **Note**: We have to check that Drizzle is initialized before fetching data. The `initialized` variable returns the drizzle store's initialization status.
 
-    ```javascript
-    <DrizzleContext.Provider drizzle={drizzle}>
-            <DrizzleContext.Consumer>
-              {drizzleContext => {
-                const {drizzle, drizzleState, initialized} = drizzleContext;
+  ```javascript
+  <DrizzleContext.Provider drizzle={drizzle}>
+    <DrizzleContext.Consumer>
+      {drizzleContext => {
+        const {drizzle, drizzleState, initialized} = drizzleContext;
 
-                if(!initialized) {
-                  return "Loading..."
-                }
+        if(!initialized) {
+          return "Loading..."
+        }
 
-                return (
-                  <MyComponent drizzle={drizzle} drizzleState={drizzleState} />
-                  )
-                }}
-            </DrizzleContext.Consumer>
-          </DrizzleContext.Provider>
-    ``` 
+        return (
+            <MyComponent drizzle={drizzle} drizzleState={drizzleState} />
+          )
+        }}
+    </DrizzleContext.Consumer>
+  </DrizzleContext.Provider>
+  ``` 
 1. Fetch contract data by accessing contracts via `drizzle` and `drizzleState` in `props`. For more information on how this works, see [How Data Stays Fresh in the Drizzle docs](https://github.com/trufflesuite/drizzle#how-data-stays-fresh). For more info on the drizzle state, see [state tree docs.](https://github.com/trufflesuite/drizzle/tree/develop/packages/store#drizzle-state)
 
-    The example below utilizes drizzle's `cacheCall` feature, which caches and synchronizes the call with the store. For more information on `cacheCall` and also `cacheSend`, see [Contract Interaction](https://www.trufflesuite.com/docs/drizzle/getting-started/contract-interaction).
-    ```javascript
-    // sample component
-    import React from 'react';
+  The example below utilizes drizzle's `cacheCall` feature, which caches and synchronizes the call with the store. For more information on `cacheCall` and also `cacheSend`, see [Contract Interaction](https://www.trufflesuite.com/docs/drizzle/getting-started/contract-interaction).
+  ```javascript
+  // sample component
+  import React from 'react';
 
-    class CacheCallExample extends React.Component {
-        state = { dataKey: null }
+  class CacheCallExample extends React.Component {
+    state = { dataKey: null }
 
-        componentDidMount() {
-            const { drizzle } = this.props;
-            const contract = drizzle.contracts.SimpleStorage;
-            let dataKey = contract.methods["storedData"].cacheCall(); // declare this call to be cached and synchronized
-            this.setState({ dataKey })
-        }
-
-        render() {
-            const { SimpleStorage } = this.props.drizzleState.contracts;
-            const displayData = SimpleStorage.storedData[this.state.dataKey] // if displayData (an object) exists, then we can display the value below
-            return (
-                <p>Hi from Truffle! Here is your storedData: {displayData && displayData.value}</p>
-            )
-        }
+    componentDidMount() {
+      const { drizzle } = this.props;
+      const contract = drizzle.contracts.SimpleStorage;
+      let dataKey = contract.methods["storedData"].cacheCall(); // declare this call to be cached and synchronized
+      this.setState({ dataKey })
     }
 
-    export default CacheCallExample
-    ```
-    **Note**: The contract instances have all the standard web3 properties and methods.
-    ```javascript
-    // sets SimpleStorage contract's storedData state variable to uint 5.
-    drizzle.contracts.SimpleStorage.methods.set(5).send();
-    ```
+    render() {
+      const { SimpleStorage } = this.props.drizzleState.contracts;
+      const displayData = SimpleStorage.storedData[this.state.dataKey]; // if displayData (an object) exists, then we can display the value below
+      return (
+        <p>Hi from Truffle! Here is your storedData: {displayData && displayData.value}</p>
+      )
+    }
+  }
+
+  export default CacheCallExample
+  ```
+  **Note**: The contract instances have all the standard web3 properties and methods.
+  ```javascript
+  drizzle.contracts.SimpleStorage.methods.set(5).send(); // sets SimpleStorage contract's storedData state variable to uint 5.
+  drizzle.contracts.SimpleStorage.methods.storedData.call(); // gets the storedData value
+  ```
 
 ## Example Code Snippet
 ```javascript
 // App.js
 import React from "react";
 import { DrizzleContext } from "@drizzle/react-plugin";
-import { Drizzle, generateStore } from "@drizzle/store";
+import { Drizzle } from "@drizzle/store";
 
 import SimpleStorage from "./contracts/SimpleStorage.json";
 import MyComponent from "./MyComponent"; // Check out drizzle's react components at @drizzle/react-components
@@ -134,28 +132,27 @@ const drizzleOptions = {
   },
 };
 
-const drizzleStore = generateStore(drizzleOptions);
-const drizzle = new Drizzle(drizzleOptions, drizzleStore)
+const drizzle = new Drizzle(drizzleOptions);
 
 const App = () => {
-    return (
-      <DrizzleContext.Provider drizzle={drizzle}>
-        <DrizzleContext.Consumer>
-          {drizzleContext => {
-            const {drizzle, drizzleState, initialized} = drizzleContext;
-            
-            if(!initialized) {
-              return "Loading..."
-            }
-            
-            return (
-              <MyComponent drizzle={drizzle} drizzleState={drizzleState} />
-              )
-            }}
-        </DrizzleContext.Consumer>
-      </DrizzleContext.Provider>
-    );
-  }
+  return (
+    <DrizzleContext.Provider drizzle={drizzle}>
+      <DrizzleContext.Consumer>
+        {drizzleContext => {
+          const {drizzle, drizzleState, initialized} = drizzleContext;
+          
+          if(!initialized) {
+            return "Loading..."
+          }
+          
+          return (
+            <MyComponent drizzle={drizzle} drizzleState={drizzleState} />
+            )
+          }}
+      </DrizzleContext.Consumer>
+    </DrizzleContext.Provider>
+  );
+}
 
 export default App;
 ```

--- a/src/docs/drizzle/react/react-integration.md
+++ b/src/docs/drizzle/react/react-integration.md
@@ -21,8 +21,6 @@ npm install @drizzle/react-plugin
 
 ## Getting Started
 
-**Note**: Since Drizzle uses web3 1.0 and web sockets, be sure your development environment can support these.
-
 1. Import the `DrizzleContext` provider.
   ```javascript
   import { DrizzleContext } from '@drizzle/react-plugin'
@@ -89,13 +87,13 @@ npm install @drizzle/react-plugin
   import React from 'react';
 
   class CacheCallExample extends React.Component {
-    state = { dataKey: null }
+    state = { dataKey: null };
 
     componentDidMount() {
       const { drizzle } = this.props;
       const contract = drizzle.contracts.SimpleStorage;
       let dataKey = contract.methods["storedData"].cacheCall(); // declare this call to be cached and synchronized
-      this.setState({ dataKey })
+      this.setState({ dataKey });
     }
 
     render() {


### PR DESCRIPTION
This PR updates the react integration doc to use drizzle v.1.5.1. This will align the docs with https://github.com/truffle-box/drizzle-box/pull/97 and https://github.com/trufflesuite/drizzle/pull/63. Once these are aligned, new users will have access to consistent, up to date documentation and examples. 

Doc updates to React Components, Quickstart, and Overview are in progress and coming soon.