### PR TITLE
Updated the correct way to install drizzle

### DIFF
--- a/src/tutorials/getting-started-with-drizzle-and-react.md
+++ b/src/tutorials/getting-started-with-drizzle-and-react.md
@@ -250,7 +250,7 @@ From there, make sure you run the `compile` and `migrate` commands again so that
 This is the most delicious part, we install Drizzle. Make sure you are in the `client` directory and then run the following:
 
 ```shell
-npm install drizzle
+npm install @drizzle/store
 ```
 
 And that's it for dependencies! Note that we don't need to install Web3.js or Truffle-Contract ourselves. Drizzle contains everything we need to work reactively with our smart contracts.


### PR DESCRIPTION
I found this in one of the git issues and believe is the correct way to install drizzle. the way mentioned in the tutorial through scrypt errors for node 12 etc.