### PR TITLE
Update references to truffle-contract

### DIFF
--- a/src/blog/axonis-enterprise-use-of-truffle.md
+++ b/src/blog/axonis-enterprise-use-of-truffle.md
@@ -18,7 +18,7 @@ This raises the question -- why use truffle for this? It seems there are at leas
 
 1. `truffle-config.js` / `truffle.js` serves as an already existing central source of shared information about various network providers relevant for a particular application developer. It only makes sense to extend this format for use in production-like environments as well.
 1. Truffle code artifacts, a battle-tested standard for smart contracts and solidity code, in particular, provide a common interface for a toolchain. By virtue of using truffle, there is no need to re-create this format. For a non-development deployment, a `contracts_build_directory` parameter is supplied, which results in a pull from a remote artifacts repository.
-1. Obviously `truffle-contract` itself provides a nice object oriented interface for deploying and performing operations on contracts within this script, thus avoiding any reinventing the wheel within the deployment library itself.
+1. Obviously `@truffle/contract` itself provides a nice object oriented interface for deploying and performing operations on contracts within this script, thus avoiding any reinventing the wheel within the deployment library itself.
 
 Thus, we ventured to build a package on top of truffle that manages configuration-driven smart contract deployments and upgrades.
 
@@ -83,4 +83,3 @@ I am pleased to announce that we plan to open-source our core Solidity smart con
 In the meantime, we hope the above at least provides a high-level example of an approach to building lightweight extensions within truffle, and as a simplifying approach to the smart contract deployment process, especially for Proxy Pattern topologies.
 
 The Axoni team and I look forward to discussing this topic and much more (such as [Axlang, our Scala-based Solidity-alternative](https://axoni.com/axlang/)) at Trufflecon.
-

--- a/src/docs/tezos/truffle/getting-started/deploying-tezos-contracts.md
+++ b/src/docs/tezos/truffle/getting-started/deploying-tezos-contracts.md
@@ -9,13 +9,13 @@ layout: docs.hbs
 
 # Deploying Tezos Contracts
 
-If you're familiar with Truffle, then you already know about [Truffle's deployment framework](/docs/truffle/getting-started/running-migrations), called Migrations, used to manage deployment changes over time. Truffle uses a stripped-down version of this system for Tezos. 
+If you're familiar with Truffle, then you already know about [Truffle's deployment framework](/docs/truffle/getting-started/running-migrations), called Migrations, used to manage deployment changes over time. Truffle uses a stripped-down version of this system for Tezos.
 
 ## Overview
 
 To deploy Tezos contracts, you'll first need to write migration scripts to tell Truffle how to deploy those contracts. In contrast with Truffle's normal behavior, all scripts defined in the `./migrations` directory will be run for every deployment. Truffle will not try to determine which scripts have been run previously, though it can be configured at runtime to only run specific deployment scripts. If you only want to run some of the scripts you've created, it'll be up to you to tell Truffle which script to run.
 
-For the rest of this document, we'll be referring to deployment scripts as "migrations" to keep in line with Truffle's normal lingo. Keep in mind that a "migration" is synonymous with "deployment script". 
+For the rest of this document, we'll be referring to deployment scripts as "migrations" to keep in line with Truffle's normal lingo. Keep in mind that a "migration" is synonymous with "deployment script".
 
 <p class="alert alert-warning">
 <strong>Coming from Ethereum?</strong> If you're already familiar with Truffle projects created for Ethereum, you'll notice a distinct lack of a `Migrations` contract. As of now, the migrations system isn't yet supported by Truffle for Tezos projects, and instead all migration scripts are run during deployment.
@@ -134,7 +134,7 @@ module.exports = function(deployer, network) {
 
 ## Available accounts
 
-Migrations are also passed the list of accounts set up in your wallet, for you to use during your deployments. 
+Migrations are also passed the list of accounts set up in your wallet, for you to use during your deployments.
 
 ```javascript
 module.exports = function(deployer, network, accounts) {
@@ -155,11 +155,11 @@ The deployer contains many functions available to simplify your migrations.
 
 Deploy a specific contract, specified by the `contract` object. This will set the address of the contract after deployment (i.e., `Contract.address` will equal the newly deployed address), and it will override any previous address stored.
 
-This function takes an optional initial state as its second argument, that sets the state of your contract on chain when deployed. The type of data passed in this argument should match the type data stored in the state represented by the contract. We use the [Tequito library](https://tezostaquito.io/) to perform the translation from Javascript representation to types understood by Tezos. Please see [their documentation](https://tezostaquito.io/docs/quick_start) for more information. 
+This function takes an optional initial state as its second argument, that sets the state of your contract on chain when deployed. The type of data passed in this argument should match the type data stored in the state represented by the contract. We use the [Tequito library](https://tezostaquito.io/) to perform the translation from Javascript representation to types understood by Tezos. Please see [their documentation](https://tezostaquito.io/docs/quick_start) for more information.
 
 The last argument is an optional object that can include the key named `overwrite`. If `overwrite` is set to `false`, the deployer won't deploy this contract if one has already been deployed. This is useful for certain circumstances where a contract address is provided by an external dependency.
 
-For more information, please see the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) documentation.
+For more information, please see the [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) documentation.
 
 
 Examples:
@@ -174,12 +174,12 @@ deployer.deploy(A, 3);
 // Don't deploy this contract if it has already been deployed.
 deployer.deploy(A, {overwrite: false});
 
-// More specific example: 
+// More specific example:
 //
 // Don't redeploy if the contract object represents an already-deployed dependency.
 // If it has already been deployed to our target network, we can skip deploying it.
 // This is useful for cases where we _do_ want to deploy that dependency for testing
-// and development networks, but we don't want to replace it in production. 
+// and development networks, but we don't want to replace it in production.
 deployer.deploy(SomeDependency, {overwrite: false});
 ```
 

--- a/src/docs/tezos/truffle/getting-started/interacting-with-your-tezos-contracts.md
+++ b/src/docs/tezos/truffle/getting-started/interacting-with-your-tezos-contracts.md
@@ -15,11 +15,11 @@ If you were writing raw requests to the Tezos network yourself in order to inter
 
 ## Making Transactions
 
-Every time you call a function against a contract on the Tezos blockchain, a transaction is recorded. Each transaction will cost you XTZ, the Tezos-specific token that powers the blockchain, and will change the blockchain's state. Transactions are powerful ways to "write" to the blockchain, and make changes that power the backend of your applications. As you'll see below, all your contract's data stored on chain, colloquially called "storage", is read from the blockchain all at once. 
+Every time you call a function against a contract on the Tezos blockchain, a transaction is recorded. Each transaction will cost you XTZ, the Tezos-specific token that powers the blockchain, and will change the blockchain's state. Transactions are powerful ways to "write" to the blockchain, and make changes that power the backend of your applications. As you'll see below, all your contract's data stored on chain, colloquially called "storage", is read from the blockchain all at once.
 
 ## Introducing abstractions
 
-Contract abstractions are the bread and butter of interacting with Tezos contracts from Javascript. In short, contract abstractions are wrapper code that makes interaction with your contracts easy, in a way that lets you forget about the many engines and gears executing under the hood. Truffle uses its own contract abstraction via the [truffle-contract](https://github.com/trufflesuite/truffle/tree/alphaTez/packages/contract) module, extended specifically for Tezos, and it is this contract abstraction that's described below.
+Contract abstractions are the bread and butter of interacting with Tezos contracts from Javascript. In short, contract abstractions are wrapper code that makes interaction with your contracts easy, in a way that lets you forget about the many engines and gears executing under the hood. Truffle uses its own contract abstraction via the [@truffle/contract](https://github.com/trufflesuite/truffle/tree/alphaTez/packages/contract) module, extended specifically for Tezos, and it is this contract abstraction that's described below.
 
 In order to appreciate the usefulness of a contract abstraction, however, we first need a contract to talk about. We'll use the very simple SimpleStorage contract available to you via `truffle unbox tezos-example` command.
 
@@ -28,7 +28,7 @@ function main (const newValue : int;  const storedValue : int) : (list(operation
   block { storedValue := newValue } with ((nil : list(operation)), storedValue)
 ```
 
-This contract has a single method, or "entry point", called `main()`. You'll notice that the first parameter to `main()` is an integer that gets stored in the contract's storage. The second parameter represents current state of the contract's storage at time of the function execution. 
+This contract has a single method, or "entry point", called `main()`. You'll notice that the first parameter to `main()` is an integer that gets stored in the contract's storage. The second parameter represents current state of the contract's storage at time of the function execution.
 
 Now let's look at the Javascript object called `SimpleStorage` provided for us by Truffle, as made available in the [Truffle console](/docs/tezos/truffle/getting-started/using-the-console-with-Tezos):
 
@@ -63,7 +63,7 @@ function add (const a : int ; const b : int) : int is a + b
 function subtract (const a : int ; const b : int) : int is a - b
 
 // real entrypoint that re-routes the flow based on the action provided
-function main (const p : action ; const s : int) : (list(operation) * int) is 
+function main (const p : action ; const s : int) : (list(operation) * int) is
   ((nil : list(operation)),
     case p of
     | Increment (n) -> add (s, n)
@@ -71,7 +71,7 @@ function main (const p : action ; const s : int) : (list(operation) * int) is
     end)
 ```
 
-If you compile this contract and spin up the console, you'll see the following when you analyze the abstraction Truffle creates for you: 
+If you compile this contract and spin up the console, you'll see the following when you analyze the abstraction Truffle creates for you:
 
 ```javascript
 truffle(development)> let instance = await Counter.deployed()
@@ -82,7 +82,7 @@ truffle(development)> instance
 // Contract
 // - address: "KT19mnZBa9KCtfv1t47gz9ieKyoxhY8JUvy8"
 // - increment: ()
-// - decrement: () 
+// - decrement: ()
 // - storage: ()
 // - send: ()
 // ...
@@ -92,11 +92,11 @@ In this example, you'll notice a curious change: `main()` has been removed, and 
 
 ## Executing contract functions
 
-Whenever you call contract functions via the abstraction, say `main()`, `increment()` or `decrement()` in the above examples, a transaction request is made against the configured Tezos network. Calling these functions from Javascript will create a transaction on the Tezos blockchain, and make a state change on the blockchain itself. You should consider these functions as "writes", where executing these functions write data to the blockchain. To perform "reads", and read storage data, you'll use the `storage()` helper function described below. 
+Whenever you call contract functions via the abstraction, say `main()`, `increment()` or `decrement()` in the above examples, a transaction request is made against the configured Tezos network. Calling these functions from Javascript will create a transaction on the Tezos blockchain, and make a state change on the blockchain itself. You should consider these functions as "writes", where executing these functions write data to the blockchain. To perform "reads", and read storage data, you'll use the `storage()` helper function described below.
 
 ### Making a transaction
 
-Making a transaction is as easy as calling the abstraction functions Truffle provides for you. 
+Making a transaction is as easy as calling the abstraction functions Truffle provides for you.
 
 To make things easy, let's start with the SimpleStorage contract defined above. Like before, let's get the deployed instance of it, but let's also call the `main()` function to send the transaction, and then once complete, request the contract's storage data:
 
@@ -113,9 +113,9 @@ BigNumber { s: 1, e: 0, c: [ 2 ] }
 
 There are a few things interesting about the above code:
 
-* We called the abstraction's `main()` function directly. 
+* We called the abstraction's `main()` function directly.
 * When calling the `main()` function, we only passed on parameter. The second (last) parameter of the `main()` function is provided by the underlying blockchain, and represents the current storage data of the contract. Because it's sent to the contract for us, we don't need to send it from the outside.
-* We received a transaction response after calling `main()`, which included a transaction hash (the `tx` parameter in the response). The transaction hash describe the id of the transaction on the blockchain. 
+* We received a transaction response after calling `main()`, which included a transaction hash (the `tx` parameter in the response). The transaction hash describe the id of the transaction on the blockchain.
 * We used the helper function, `storage()`, to get the storage data of the contract. The data of this particular contract is an integer, and in Javascript is represented by the BigNumber object, in this case with the value of `2`. This happens to be the value we sent to `main()` within our transaction!
 
 This is all well and good. Now let's try it with a multi-entrypoint contract:
@@ -132,7 +132,7 @@ truffle(development)> await instance.storage()  // Get storage data
 BigNumber { s: 1, e: 0, c: [ 3 ] }
 ```
 
-This is very similar to the example above, except in this case we didn't call `main()`. We instead called one of the named entry points, `increment()`, and it was treated as a transaction, exactly as if we had called `main()`. 
+This is very similar to the example above, except in this case we didn't call `main()`. We instead called one of the named entry points, `increment()`, and it was treated as a transaction, exactly as if we had called `main()`.
 
 ### Reading contract data
 
@@ -152,7 +152,7 @@ What's interesting here:
 **Warning**: If you try to convert a BigNumber that's larger than the largest integer supported by Javascript, you'll likely run into errors or unexpected behavior. We suggest using BigNumber throughout your application.
 </p>
 
-Note that the data you get back from the `storage()` function will represent the types and structure of the underlying data stored in your contract. Let's take a new example we haven't seen yet: 
+Note that the data you get back from the `storage()` function will represent the types and structure of the underlying data stored in your contract. Let's take a new example we haven't seen yet:
 
 ```
 // ExpandedStorage.ligo - much like SimpleStorage, but stores two values!
@@ -164,7 +164,7 @@ function main (const newValues : values;  const storedValues : values) : (list(o
   block { storedValues := newValues } with ((nil : list(operation)), storedValues)
 ```
 
-In this contract, the contract's storage is represented by a LIGO record object that contains two integers, the first named `firstValue`, and the second named `secondValue`. When you call `storage()` from the Truffle console, you'll see you're given data that respresents the same structure: 
+In this contract, the contract's storage is represented by a LIGO record object that contains two integers, the first named `firstValue`, and the second named `secondValue`. When you call `storage()` from the Truffle console, you'll see you're given data that respresents the same structure:
 
 ```javascript
 truffle(development)> let instance = await ExpandedStorage.deployed()

--- a/src/docs/truffle/advanced/build-processes.md
+++ b/src/docs/truffle/advanced/build-processes.md
@@ -66,7 +66,7 @@ When configuring your build tool or application, you'll need to perform the foll
 
 1) Get all your contract artifacts into your build pipeline / application. This includes all of the `.json` files within the `./build/contracts` directory.
 
-2) Turn those `.json` contract artifacts into contract abstractions that are easy to use, via [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract).
+2) Turn those `.json` contract artifacts into contract abstractions that are easy to use, via [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract).
 
 3) Provision those contract abstractions with a Web3 provider. In the browser, this provider might come from [Metamask](https://metamask.io/) or [Mist](https://github.com/ethereum/mist), but it could also be a custom provider you've configured to point to [Infura](http://infura.io/) or any other Ethereum client.
 
@@ -79,7 +79,7 @@ In Node, this is very easy to do. Let's take a look at an example that shows off
 var json = require("./build/contracts/MyContract.json");
 
 // Step 2: Turn that contract into an abstraction I can use
-var contract = require("truffle-contract");
+var contract = require("@truffle/contract");
 var MyContract = contract(json);
 
 // Step 3: Provision the contract with a web3 provider

--- a/src/docs/truffle/advanced/networks-and-app-deployment.md
+++ b/src/docs/truffle/advanced/networks-and-app-deployment.md
@@ -22,7 +22,7 @@ In this example, Truffle will run your migrations on the "live" network, which -
 
 ## Build artifacts
 
-As mentioned in the [Compiling contracts](/docs/truffle/getting-started/compiling-contracts) section, build artifacts are stored in the `./build/contracts` directory as `.json` files. When you compile your contracts or run your migrations using a specific network, Truffle will update those `.json` files so they contain the information related to that network. When those artifacts are used later -- such as within your frontend or application via [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) -- they'll automatically detect which network the Ethereum client is connected to and use the correct contract artifacts accordingly.
+As mentioned in the [Compiling contracts](/docs/truffle/getting-started/compiling-contracts) section, build artifacts are stored in the `./build/contracts` directory as `.json` files. When you compile your contracts or run your migrations using a specific network, Truffle will update those `.json` files so they contain the information related to that network. When those artifacts are used later -- such as within your frontend or application via [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) -- they'll automatically detect which network the Ethereum client is connected to and use the correct contract artifacts accordingly.
 
 ## Application deployment
 

--- a/src/docs/truffle/getting-started/interacting-with-your-contracts.md
+++ b/src/docs/truffle/getting-started/interacting-with-your-contracts.md
@@ -34,7 +34,7 @@ Choosing between a transaction and a call is as simple as deciding whether you w
 
 ## Introducing abstractions
 
-Contract abstractions are the bread and butter of interacting with Ethereum contracts from Javascript. In short, contract abstractions are wrapper code that makes interaction with your contracts easy, in a way that lets you forget about the many engines and gears executing under the hood. Truffle uses its own contract abstraction via the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) module, and it is this contract abstraction that's described below.
+Contract abstractions are the bread and butter of interacting with Ethereum contracts from Javascript. In short, contract abstractions are wrapper code that makes interaction with your contracts easy, in a way that lets you forget about the many engines and gears executing under the hood. Truffle uses its own contract abstraction via the [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) module, and it is this contract abstraction that's described below.
 
 In order to appreciate the usefulness of a contract abstraction, however, we first need a contract to talk about. We'll use the MetaCoin contract available to you through Truffle Boxes via `truffle unbox metacoin`.
 
@@ -155,7 +155,7 @@ Specifically, you get the following:
 * `result.logs` *(array)* - Decoded events (logs)
 * `result.receipt` *(object)* - Transaction receipt (includes the amount of gas used)
 
-For more information, please see the [README](https://github.com/trufflesuite/truffle/tree/master/packages/contract) in the `truffle-contract` package.
+For more information, please see the [README](https://github.com/trufflesuite/truffle/tree/master/packages/contract) in the `@truffle/contract` package.
 
 ### Catching events
 
@@ -301,4 +301,4 @@ Please see this issue [here](https://github.com/trufflesuite/truffle/issues/2868
 
 ## Further reading
 
-The contract abstractions provided by Truffle contain a wealth of utilities for making interacting with your contracts easy. Check out the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) documentation for tips, tricks and insights.
+The contract abstractions provided by Truffle contain a wealth of utilities for making interacting with your contracts easy. Check out the [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) documentation for tips, tricks and insights.

--- a/src/docs/truffle/getting-started/package-management-via-npm.md
+++ b/src/docs/truffle/getting-started/package-management-via-npm.md
@@ -44,10 +44,10 @@ Since the path didn't start with `./`, Truffle knows to look in your project's `
 
 ### Within JavaScript code
 
-To interact with package's contracts within JavaScript code, you simply need to `require` that package's `.json` files, and then use the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) module to turn those into usable abstractions:
+To interact with package's contracts within JavaScript code, you simply need to `require` that package's `.json` files, and then use the [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) module to turn those into usable abstractions:
 
 ```javascript
-var contract = require("truffle-contract");
+var contract = require("@truffle/contract");
 var data = require("example-truffle-library/build/contracts/SimpleNameRegistry.json");
 var SimpleNameRegistry = contract(data);
 ```

--- a/src/docs/truffle/getting-started/running-migrations.md
+++ b/src/docs/truffle/getting-started/running-migrations.md
@@ -179,7 +179,7 @@ You can optionally pass an array of contracts, or an array of arrays, to speed u
 
 Note that you will need to deploy and link any libraries your contracts depend on first before calling `deploy`. See the `link` function below for more details.
 
-For more information, please see the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) documentation.
+For more information, please see the [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) documentation.
 
 
 Examples:

--- a/src/docs/truffle/getting-started/truffle-with-metamask.md
+++ b/src/docs/truffle/getting-started/truffle-with-metamask.md
@@ -4,10 +4,10 @@ layout: docs.hbs
 ---
 # Truffle and MetaMask
 
-Before you can interact with smart contracts in a browser, make sure they're compiled, deployed, and that you're interacting with them via `web3` in client-side JavaScript. We recommend using the [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) library, as it makes interacting with contracts easier and more robust.
+Before you can interact with smart contracts in a browser, make sure they're compiled, deployed, and that you're interacting with them via `web3` in client-side JavaScript. We recommend using the [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) library, as it makes interacting with contracts easier and more robust.
 
 <p class="alert alert-info">
-<strong>Note</strong>: For more information on these topics, including using `truffle-contract`, check out our [Pet Shop](/tutorials/pet-shop) or [TutorialToken](/tutorials/robust-smart-contracts-with-openzeppelin) tutorials.
+<strong>Note</strong>: For more information on these topics, including using `@truffle/contract`, check out our [Pet Shop](/tutorials/pet-shop) or [TutorialToken](/tutorials/robust-smart-contracts-with-openzeppelin) tutorials.
 </p>
 
 Once you've done the above, you're ready to use MetaMask.

--- a/src/docs/truffle/reference/contract-abstractions.md
+++ b/src/docs/truffle/reference/contract-abstractions.md
@@ -93,7 +93,7 @@ This function creates a new instance of the contract abstraction representing th
 
 #### `MyContract.deployed()`
 
-Creates an instance of the contract abstraction representing the contract at its deployed address. The deployed address is a special value given to truffle-contract that, when set, saves the address internally so that the deployed address can be inferred from the given Ethereum network being used. This allows you to write code referring to a specific deployed contract without having to manage those addresses yourself. Like `at()`, `deployed()` is thenable, and will resolve to a contract abstraction instance representing the deployed contract after ensuring that code exists at that location and that that address exists on the network being used.
+Creates an instance of the contract abstraction representing the contract at its deployed address. The deployed address is a special value given to @truffle/contract that, when set, saves the address internally so that the deployed address can be inferred from the given Ethereum network being used. This allows you to write code referring to a specific deployed contract without having to manage those addresses yourself. Like `at()`, `deployed()` is thenable, and will resolve to a contract abstraction instance representing the deployed contract after ensuring that code exists at that location and that that address exists on the network being used.
 
 #### `MyContract.link(instance)`
 
@@ -255,7 +255,7 @@ const value = await instance.getValue.call();
 // since the contract returns that value.
 ```
 
-Even more helpful, however is we *don't even need* to use `.call` when a function is marked as `view` or `pure` (or the deprecated `constant`), because `truffle-contract` will automatically know that that function can only be interacted with via a call:
+Even more helpful, however is we *don't even need* to use `.call` when a function is marked as `view` or `pure` (or the deprecated `constant`), because `@truffle/contract` will automatically know that that function can only be interacted with via a call:
 
 ```javascript
 const value = await instance.getValue();

--- a/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
+++ b/src/tutorials/building-dapps-for-quorum-private-enterprise-blockchains.md
@@ -336,7 +336,7 @@ We originally configured Truffle to point our development environment to the fir
 
 So far, we've shown you how to deploy contracts that are private within your migrations. When building a dapp on Quorum, it'd also be helpful to learn how to make *all* transactions private.
 
-Truffle uses its [truffle-contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) contract abstraction wherever contracts are used in JavaScript. When you interacted with `SimpleStorage` in the console above, for instance, you were using a `truffle-contract` contract abstraction. These abstractions are also used within your migrations, your JavaScript-based unit tests, as well as executing external scripts with Truffle.
+Truffle uses its [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) contract abstraction wherever contracts are used in JavaScript. When you interacted with `SimpleStorage` in the console above, for instance, you were using a `@truffle/contract` contract abstraction. These abstractions are also used within your migrations, your JavaScript-based unit tests, as well as executing external scripts with Truffle.
 
 Truffle's contract abstraction allow you to make a transaction against any function available on the contract. It does so by evaluating the functions of the contract and making them available to JavaScript. To see these transactions in action, we're going to use an advanced feature of Truffle that lets us execute external scripts within our Truffle environment.
 

--- a/src/tutorials/building-testing-frontend-app-truffle-3.md
+++ b/src/tutorials/building-testing-frontend-app-truffle-3.md
@@ -1,5 +1,5 @@
 <p class="alert alert-info">
-**Update**: While this tutorial was originally written for Truffle 3, we have updated it to be fully compatible with newer versions of Truffle. We have kept some of the language unaltered, except where necessary. 
+**Update**: While this tutorial was originally written for Truffle 3, we have updated it to be fully compatible with newer versions of Truffle. We have kept some of the language unaltered, except where necessary.
 </p>
 
 Truffle 3 is out and switched to less opinionated build process that allows any build pipeline to be plugged in. We're going to take advantage of that feature today, and build a frontend app with a custom pipeline.
@@ -52,7 +52,7 @@ This is the default setting for [Ganache](/docs/ganache/using), though you can c
 
 Let's get the contracts on the network:
 
-First run `truffle compile`. This will compile the `.sol` contracts into `.json` artifacts (specified in the [`truffle-contract`](https://github.com/trufflesuite/truffle/tree/master/packages/contract) library). They will appear in `build/contracts/*.json`. Now we can include contracts in our app with a simple `import` or `require` statement:
+First run `truffle compile`. This will compile the `.sol` contracts into `.json` artifacts (specified in the [`@truffle/contract`](https://github.com/trufflesuite/truffle/tree/master/packages/contract) library). They will appear in `build/contracts/*.json`. Now we can include contracts in our app with a simple `import` or `require` statement:
 
 ```javascript
 // Import our contract artifacts and turn them into usable abstractions.

--- a/src/tutorials/creating-a-cli-with-truffle-3.md
+++ b/src/tutorials/creating-a-cli-with-truffle-3.md
@@ -112,7 +112,7 @@ Here's [index.js](https://github.com/dougvk/ens-registrar3/blob/master/index.js)
 ```javascript
 import { default as ENSAuctionLib } from './lib/ens_registrar'
 import { default as Web3 } from 'web3'
-import { default as contract } from 'truffle-contract'
+import { default as contract } from '@truffle/contract'
 
 const AuctionRegistrar = contract(require('./build/contracts/Registrar.json'))
 const Deed = contract(require('./build/contracts/Deed.json'))
@@ -128,7 +128,7 @@ export default function (host, port, registrarAddress, fromAddress) {
   )
 }
 ```
-Here I'm using the same library, `truffle-contract`, that `artifacts.require` uses under the hood. Because I can't rely on the Truffle framework within the CLI, I have to include the compiled contract artifacts manually. The rest is passed in through the CLI in `bin/ensa.js`:
+Here I'm using the same library, `@truffle/contract`, that `artifacts.require` uses under the hood. Because I can't rely on the Truffle framework within the CLI, I have to include the compiled contract artifacts manually. The rest is passed in through the CLI in `bin/ensa.js`:
 ```javascript
 import { default as initializeLib } from '../index'
 ...

--- a/src/tutorials/getting-started-with-drizzle-and-react.md
+++ b/src/tutorials/getting-started-with-drizzle-and-react.md
@@ -253,7 +253,7 @@ This is the most delicious part, we install Drizzle. Make sure you are in the `c
 npm install drizzle
 ```
 
-And that's it for dependencies! Note that we don't need to install Web3.js or Truffle-Contract ourselves. Drizzle contains everything we need to work reactively with our smart contracts.
+And that's it for dependencies! Note that we don't need to install Web3.js or @truffle/contract ourselves. Drizzle contains everything we need to work reactively with our smart contracts.
 
 ## Wire up the React app with Drizzle
 

--- a/src/tutorials/pet-shop.md
+++ b/src/tutorials/pet-shop.md
@@ -454,13 +454,13 @@ Things to notice:
 
 ### Instantiating the contract
 
-Now that we can interact with Ethereum via web3, we need to instantiate our smart contract so web3 knows where to find it and how it works. Truffle has a library to help with this called `truffle-contract`. It keeps information about the contract in sync with migrations, so you don't need to change the contract's deployed address manually.
+Now that we can interact with Ethereum via web3, we need to instantiate our smart contract so web3 knows where to find it and how it works. Truffle has a library to help with this called `@truffle/contract`. It keeps information about the contract in sync with migrations, so you don't need to change the contract's deployed address manually.
 
 1. Still in `/src/js/app.js`, remove the multi-line comment from within `initContract` and replace it with the following:
 
    ```javascript
    $.getJSON('Adoption.json', function(data) {
-     // Get the necessary contract artifact file and instantiate it with truffle-contract
+     // Get the necessary contract artifact file and instantiate it with @truffle/contract
      var AdoptionArtifact = data;
      App.contracts.Adoption = TruffleContract(AdoptionArtifact);
 


### PR DESCRIPTION
Update references to the 'truffle-contract' library to use '@truffle/contract' instead.

There are some more references to `truffle-contract` [here](https://github.com/trufflesuite/trufflesuite.com/blob/develop/src/blog/truffle-v5-has-arrived.md) and [here](https://github.com/trufflesuite/trufflesuite.com/blob/develop/src/tutorials/upgrading-from-truffle-2-to-3.md) which we could consider changing as well but they are not really relevant any more. I'm not sure what we should do for those. 