### PR TITLE
Discuss stack traces in test documentation

### DIFF
--- a/src/docs/truffle/testing/testing-your-contracts.md
+++ b/src/docs/truffle/testing/testing-your-contracts.md
@@ -38,3 +38,9 @@ Truffle provides a clean room environment when running your test files. When run
 ## Speed and reliability considerations
 
 Both Ganache and Truffle Develop are significantly faster than other clients when running automated tests. Moreover, they contain special features which Truffle takes advantage of to speed up test runtime by almost 90%. As a general workflow, we recommend you use Ganache or Truffle Develop during normal development and testing, and then run your tests once against go-ethereum or another official Ethereum client when you're gearing up to deploy to live or production networks.
+
+## Stack Traces
+
+You can obtain Solidity stack traces for failed transactions with `truffle test --stacktrace`.  This will produce stack traces for transactions and deployments made via Truffle Contract during your tests should one of them revert and thereby causes your test to fail.  This option is still experimental, and stack traces are not currently supported for calls or gas estimates.  Moreover, while it is turned on, `PromiEvent` functionality of Truffle Contract (as opposed to `Promise` functionality) may not work.
+
+There is also the option `truffle test --stacktrace-extra`.  This will turn on stack traces and will additionally compile contracts in Solidity's debug mode for additional revert messages.  This debug mode was only introduced in Solidity 0.6.3 so it will have no effect on earlier versions of Solidity.  Using debug mode may cause problems on larger contracts.


### PR DESCRIPTION
This PR adds documentation for `truffle test --stacktrace`.