### PR TITLE
Various updates to reference documentation

### DIFF
--- a/src/docs/truffle/getting-started/debugging-your-contracts.md
+++ b/src/docs/truffle/getting-started/debugging-your-contracts.md
@@ -27,6 +27,8 @@ In order to debug transactions, you'll need the following:
 
 Note that it's okay if your desired transaction resulted in an exception or if it ran out of gas. The transaction still exists on chain, and so you can still debug it!
 
+Warning: Debugging a transaction against a contract that was compiled with optimization enabled may not work reliably.
+
 ## In-test debugging
 
 Truffle v5.1 and above provides the `truffle test --debug` flag and associated

--- a/src/docs/truffle/getting-started/debugging-your-contracts.md
+++ b/src/docs/truffle/getting-started/debugging-your-contracts.md
@@ -173,6 +173,10 @@ This command allows you to remove any of your existing breakpoints, with the sam
 
 This command will cause execution of the code to continue until the next breakpoint is reached or the last line is executed.
 
+### (:) evaluate and print expression
+
+This command will evaluate and print the given expression, based on the current variables and their values (see also `v`).
+
 ### (+) add watch expression
 
 This command will add a watch on a provided expression, based on the following syntax: `+:<expression>`.

--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -95,7 +95,11 @@ For each network, if unspecified, transaction options will default to the follow
 * `provider`: Default web3 provider using `host` and `port` options: `new Web3.providers.HttpProvider("http://<host>:<port>")`
 * `websockets`: You will need this enabled to use the `confirmations` listener or to hear Events using `.on` or `.once`.  Default is `false`.
 
-For each network, you can specify `host` / `port`, or `url`, or `provider`, but not more than one. If you need an HTTP provider, we recommend using `host` and `port`, or `url`, while if you need a custom provider such as `HDWalletProvider`, you must use `provider`.  The `url` option also supports WebSockets.
+For each network, you can specify `host` / `port`, `url`, or `provider`, but not more than one. If you need an HTTP provider, we recommend using `host` and `port`, or `url`, while if you need a custom provider such as `HDWalletProvider`, you must use `provider`.  The `url` option also supports WebSockets and SSL. `url` should include the full url; see the examples below:
+- http://127.0.0.1:8545
+- ws://127.0.0.1:8545
+- https://sandbox.truffleteams.com/yoursandboxid
+- wss://sandbox.truffleteams.com/yoursandboxid
 
 #### Providers
 

--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -95,7 +95,7 @@ For each network, if unspecified, transaction options will default to the follow
 * `provider`: Default web3 provider using `host` and `port` options: `new Web3.providers.HttpProvider("http://<host>:<port>")`
 * `websockets`: You will need this enabled to use the `confirmations` listener or to hear Events using `.on` or `.once`.  Default is `false`.
 
-For each network, you can specify either `host` / `port` or `provider`, but not both. If you need an HTTP provider, we recommend using `host` and `port`, while if you need a custom provider such as `HDWalletProvider`, you must use `provider`.
+For each network, you can specify `host` / `port`, or `url`, or `provider`, but not more than one. If you need an HTTP provider, we recommend using `host` and `port`, or `url`, while if you need a custom provider such as `HDWalletProvider`, you must use `provider`.  The `url` option also supports WebSockets.
 
 #### Providers
 
@@ -218,7 +218,7 @@ In the `compilers` object you can specify settings related to the compilers used
 
 ### solc
 
-Solidity compiler settings. Supports optimizer settings for `solc`.
+Solidity compiler settings. Supports optimizer settings for `solc`, as well as other settings such as debug and metadata settings.
 
 You may specify...
 + any solc-js version listed at [solc-bin](http://solc-bin.ethereum.org/bin/list.json). Specify the one you want and Truffle will get it for you.

--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -55,15 +55,17 @@ Options:
 
 ### config
 
-Display whether analytics are enabled or disabled and prompt whether to toggle the setting.
+Displays and sets user-level configuration options.
 
 ```shell
-truffle config [--enable-analytics|--disable-analytics]
+truffle config [--enable-analytics|--disable-analytics] [[<get|set> <key>] [<value-for-set>]]
 ```
 
 Options:
 
 * `--enable-analytics|--disable-analytics`: Enable or disable analytics.
+* `get`: Get a Truffle configuration option value.
+* `set`: Set a Truffle configuration option value.
 
 
 ### console
@@ -107,19 +109,16 @@ Camel case names of artifacts will be converted to underscore-separated file nam
 Interactively debug any transaction on the blockchain.
 
 ```shell
-truffle debug <transaction_hash>
+truffle debug [<transaction_hash>] [--network <network>]
 ```
 
 Will start an interactive debugging session on a particular transaction. Allows you to step through each action and replay. See the [Debugging your contracts](/docs/getting_started/debugging) section for more details.
 
-<p class="alert alert-warning">
-**Alert**: This command is considered experimental.
-</p>
 
+Options:
 
-Option:
-
-* `<transaction_hash>`: Transaction ID to use for debugging. (required)
+* `<transaction_hash>`: Transaction ID to use for debugging.  You can omit this to simply start the debugger and then load a transaction later.
+* `--network`: The network to connect to.
 
 
 ### deploy
@@ -221,7 +220,7 @@ See the [Package Management with EthPM](/docs/getting_started/packages-ethpm) se
 Run migrations to deploy contracts.
 
 ```shell
-truffle migrate [--reset] [--f <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--dry-run] [--interactive]
+truffle migrate [--reset] [--f <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--dry-run] [--interactive] [--skip-dry-run] [--describe-json]
 ```
 
 Unless specified, this will run from the last completed migration. See the [Migrations](/docs/getting_started/migrations) section for more details.
@@ -235,7 +234,9 @@ Options:
 * `--compile-all`: Compile all contracts instead of intelligently choosing which contracts need to be compiled.
 * `--verbose-rpc`: Log communication between Truffle and the Ethereum client.
 * `--dry-run`: Fork the network specified and only perform a test migration.
+* `--skip-dry-run`: Skip the test migration performed before the real migration.
 * `--interactive`: Prompt to confirm that the user wants to proceed after the dry run.
+* `--describe-json`: Prints additional status messages.
 
 
 ### networks
@@ -251,6 +252,18 @@ Use this command before publishing your package to see if there are any extraneo
 Option:
 
 * `--clean`: Remove all network artifacts that aren't associated with a named network.
+
+### obtain
+
+Fetch and cache a specified compiler.
+
+```shell
+truffle obtain [--solc <version>]
+```
+
+Option:
+
+* `--solc`: Download and cache a version of the solc compiler. (required)
 
 
 ### opcode
@@ -302,7 +315,7 @@ to recognize the plugin. For more information, see [Third-Party Plugin Commands]
 Run JavaScript and Solidity tests.
 
 ```shell
-truffle test [<test_file>] [--compile-all] [--network <name>] [--verbose-rpc] [--show-events]
+truffle test [<test_file>] [--compile-all[-debug]] [--network <name>] [--verbose-rpc] [--show-events] [--debug] [--debug-global <identifier>] [--bail] [--stacktrace[-extra]]
 ```
 
 Runs some or all tests within the `test/` directory as specified. See the section on [Testing your contracts](/docs/getting_started/testing) for more information.
@@ -311,9 +324,15 @@ Options:
 
 * `<test_file>`: Name of the test file to be run. Can include path information if the file does not exist in the current directory.
 * `--compile-all`: Compile all contracts instead of intelligently choosing which contracts need to be compiled.
+* `--compile-all-debug`: Like `--compile-all`, but compiles contracts in debug mode for extra information.  Has no effect on Solidity <0.6.3.
 * `--network <name>`: Specify the network to use, using artifacts specific to that network. Network name must exist in the configuration.
 * `--verbose-rpc`: Log communication between Truffle and the Ethereum client.
 * `--show-events`: Log all contract events.
+* `--debug`: Provides global `debug()` function for in-test debugging. Usable with Javascript tests only; implies `--compile-all`.
+* `--debug-global <identifier>`: Allows one to rename the `debug()` function to something else.
+* `--bail`: Bail after the first test failure.  May be abbreviated `-b`.
+* `--stacktrace`: Allows for mixed Javascript-and-Solidity stacktraces when a Truffle Contract transaction or deployment reverts.  Does not apply to calls or gas estimates.  Implies `--compile-all`.  May be abbreviated `-t`.  Warning: This option is still somewhat experimental.
+* `--stacktrace-extra`: Shortcut for `--stacktrace --compile-all-debug`.
 
 
 ### unbox
@@ -321,7 +340,7 @@ Options:
 Download a Truffle Box, a pre-built Truffle project.
 
 ```shell
-truffle unbox <box_name>
+truffle unbox <box_name> [--force]
 ```
 
 Downloads a [Truffle Box](/boxes) to the current working directory. See the [list of available boxes](/boxes).


### PR DESCRIPTION
Our reference documentation is pretty out of date, so I went to go update it.  I updated the `config` documentation with @seesemichaelj's new `url` option, and also mentioned that `solc.settings` covers other Solc settings, not just optimization.

I updated the Truffle command reference with all sorts of new or missing stuff.

Also, not reference documentation, but I added a warning to the debugger documentation that it may not work reliably with optimized code.