### PR TITLE
feat: alignment of Github wrapper buttons for front-page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -19,32 +19,35 @@ social-description: World class development environment for blockchain dapps (de
 
   <div class="row" id="contentBegins">
     <div class="col">
-      <h2 class="text-truffle mt-5"><span class="narrow">T</span>RUFFLE</h2>
+      <h2 class="text-truffle mt-5"><span class="narrow">T</span>RUFFLE
+        <div class="github-button-wrapper">
+          <a class="github-button" href="https://github.com/trufflesuite/truffle" data-size="large"  data-show-count="true" aria-label="Star trufflesuite/truffle on GitHub">Star</a>
+        </div>
+      </h2>
       <h5 class="color-truffle">SMART CONTRACTS MADE SWEETER</h5>
-      <div class="github-button-wrapper">
-        <a class="github-button" href="https://github.com/trufflesuite/truffle" data-size="large"  data-show-count="true" aria-label="Star trufflesuite/truffle on GitHub">Star</a>
-      </div>
 
       <p>A world class development environment, testing framework and asset pipeline for blockchains using the Ethereum Virtual Machine (EVM), aiming to make life as a developer easier.</p>
       <a href="/truffle" class="btn btn-truffle">LEARN MORE</a>
       <a href="https://github.com/trufflesuite/truffle" class="btn btn-truffle">GITHUB REPO</a>
       <a href="/docs/truffle/overview" class="btn btn-truffle">DOCS</a>
-      <h2 class="text-ganache mt-5">Ganache</h2>
+      <h2 class="text-ganache mt-5">Ganache
+        <div class="github-button-wrapper">
+          <a class="github-button" href="https://github.com/trufflesuite/ganache" data-size="large"  data-show-count="true" aria-label="Star trufflesuite/ganache on GitHub">Star</a>
+        </div>
+      </h2>
       <h5 class="color-ganache">ONE CLICK BLOCKCHAIN</h5> 
-      <div class="github-button-wrapper">
-        <a class="github-button" href="https://github.com/trufflesuite/ganache" data-size="large"  data-show-count="true" aria-label="Star trufflesuite/ganache on GitHub">Star</a>
-      </div>
       
       <p>A personal blockchain for Ethereum development you can use to deploy contracts, develop your applications, and run tests. It is available as both a desktop application as well as a command-line tool (formerly known as the TestRPC). Ganache is available for Windows, Mac, and Linux.</p>
       <a href="/ganache" class="btn btn-ganache">LEARN MORE</a>
       <a href="https://github.com/trufflesuite/ganache" class="btn btn-ganache">GITHUB REPO</a>
       <a href="/docs/ganache/overview" class="btn btn-ganache">DOCS</a>
 
-      <h2 class="text-drizzle mt-5">dri<span class="drizzle-z-skew-1">z</span><span class="drizzle-z-skew-2">z</span>le</h2>
+      <h2 class="text-drizzle mt-5">dri<span class="drizzle-z-skew-1">z</span><span class="drizzle-z-skew-2">z</span>le
+        <div class="github-button-wrapper">
+          <a class="github-button" href="https://github.com/trufflesuite/drizzle" data-size="large"  data-show-count="true" aria-label="Star trufflesuite/drizzle on GitHub">Star</a>
+        </div>
+      </h2>
       <h5 class="color-drizzle">FRESH CHAIN-DATA FOR FRONT-ENDS</h5>
-      <div class="github-button-wrapper">
-        <a class="github-button" href="https://github.com/trufflesuite/drizzle" data-size="large"  data-show-count="true" aria-label="Star trufflesuite/drizzle on GitHub">Star</a>
-      </div>
       <p>A collection of front-end libraries that make writing dapp front-ends easier and more predictable. The core of Drizzle is based on a Redux store, so you have access to the spectacular development tools around Redux. We take care of synchronizing your contract data, transaction data and more.</p>
       <a href="/drizzle" class="btn btn-drizzle">LEARN MORE</a>
       <a href="https://github.com/trufflesuite/drizzle" class="btn btn-drizzle">GITHUB REPO</a>

--- a/src/sass/pages/home.scss
+++ b/src/sass/pages/home.scss
@@ -91,7 +91,14 @@
   .github-button-wrapper {
     margin-left: 1rem;
     display: inline-block;
-    vertical-align: middle
+    vertical-align: middle;
+    letter-spacing: 0;
+    text-transform: none;
+
+    @media (max-width: 767px) {
+      float: right;
+      margin-right: 0.75rem;
+    }
   }
 
   h5 {


### PR DESCRIPTION
The Github Wrapper Buttons within the frontpage screen look clustered within smaller screen width. Hence, the proposed changes give a structured layout with no clustering of elements taking place.

### The change to layout with Github Buttons
![alignment-button-frontpage-truffle](https://user-images.githubusercontent.com/44139348/89549314-ca70c880-d825-11ea-835e-5759e5088581.png)