### PR TITLE
Add warning for node version

### DIFF
--- a/src/docs/truffle/getting-started/creating-a-project.md
+++ b/src/docs/truffle/getting-started/creating-a-project.md
@@ -3,6 +3,7 @@ title: Truffle | Creating a Project
 layout: docs.hbs
 ---
 # Creating a Project
+Before you start, ensure that you are running Node v10 or Node v12. Other versions of node are not officially supported yet, and could cause problems.
 
 To use most Truffle commands, you need to run them against an existing Truffle project. So the first step is to create a Truffle project.
 

--- a/src/docs/truffle/quickstart.md
+++ b/src/docs/truffle/quickstart.md
@@ -76,6 +76,7 @@ Once this operation is completed, you'll now have a project structure with the f
 1. Open the `truffle-config.js` file. This is the Truffle [configuration file](/docs/truffle/reference/configuration), for setting network information and other project-related settings. The file is blank, but this is okay, as we'll be using a Truffle command that has some defaults built-in.
 
 ## Testing
+Before you start testing, ensure that you are running Node v10 or Node v12. Other versions of node are not officially supported yet, and could cause problems.
 
 1. On a terminal, run the Solidity test:
 


### PR DESCRIPTION
This tutorial will not work if you are running an incompatible version of Node. See here: https://github.com/trufflesuite/truffle/issues/3262

This PR adds a warning in the tutorial. 

@DiscRiskandBisque 
