### PR TITLE
feat: minimize image size within blog

### DIFF
--- a/src/sass/pages/blog.scss
+++ b/src/sass/pages/blog.scss
@@ -27,6 +27,13 @@
   border: 4px solid #3fe0c5;
 }
 
+@media screen and (max-width: 767px) {
+  .post-thumbnail {
+    margin: 1rem auto;
+    width: 50%;
+  }
+}
+
 .post-trufflecon-box {
   background: #e0dad7;
   padding: 1.5rem;


### PR DESCRIPTION
I observed that the images take a lot of space within the blog section in smaller screen width. Thus, I have proposed the following changes. It's a minor change but gives a better outlook for smaller screens.

### Before
![before-blog-image-truffle](https://user-images.githubusercontent.com/44139348/92009962-d8ebca80-ed66-11ea-8c90-d32fd3a2d09e.png)

### After
![after-blog-image-truffle](https://user-images.githubusercontent.com/44139348/92010182-1f412980-ed67-11ea-8f9e-cc78b28b07ea.png)
