### PR TITLE
Add documentation for new/fixed request method

### DIFF
--- a/src/docs/truffle/getting-started/interacting-with-your-contracts.md
+++ b/src/docs/truffle/getting-started/interacting-with-your-contracts.md
@@ -231,6 +231,7 @@ methods of your contract abstractions:
 - `estimateGas`
 - `sendTransaction`
 - `call`
+- `request`
 
 The first special method mentioned above is the `estimateGas` method. This, as you
 probably can guess, estimates the amount of gas that a transaction will require.
@@ -275,11 +276,18 @@ The `result` variable above will be the same kind of result you would get
 from executing any normal transaction in Truffle. It will contain the
 transaction hash, the logs, etc.
 
-The last method is `call` and the syntax is exactly the same as for
+The next method is `call` and the syntax is exactly the same as for
 `sendTransaction`. If you want to explicitly make a call, you can
 use the `call` method found on your contract abstraction's method. So you
 would write something that looks like
 `const result = await instance.myMethod.call()`.
+
+The last method is `request`; this method does not perform a transaction or
+call, but rather returns an object that can be passed to
+`web3.eth.sendTransaction` or `web3.eth.call` if you want to perform the
+transaction or call yourself.  It has the same syntax as the others; and
+like with `estimateGas`, you can also do `Contract.new.request()` if you
+want to perform a manual deployment.
 
 ### Invoking overloaded methods
 

--- a/src/docs/truffle/getting-started/interacting-with-your-contracts.md
+++ b/src/docs/truffle/getting-started/interacting-with-your-contracts.md
@@ -282,10 +282,10 @@ use the `call` method found on your contract abstraction's method. So you
 would write something that looks like
 `const result = await instance.myMethod.call()`.
 
-The last method is `request`; this method does not perform a transaction or
+The last method is `request`.  This method does not perform a transaction or
 call, but rather returns an object that can be passed to
 `web3.eth.sendTransaction` or `web3.eth.call` if you want to perform the
-transaction or call yourself.  It has the same syntax as the others; and
+transaction or call yourself.  It has the same syntax as the others, and
 like with `estimateGas`, you can also do `Contract.new.request()` if you
 want to perform a manual deployment.
 


### PR DESCRIPTION
[Earlier](https://github.com/trufflesuite/truffle/pull/3321) I fixed/added the `request` method to contract methods.  But I didn't think to add it to the documentation!  Doing that now.