### PR TITLE
add sandboxes docs

### DIFF
--- a/src/docs/data.json
+++ b/src/docs/data.json
@@ -9,6 +9,14 @@
       "Starting Builds",
       "External CI"
     ],
+    "Sandboxes": [
+      "Sandboxes overview",
+      "Creating a sandbox",
+      "Renaming a sandbox",
+      "Destroying a sandbox",
+      "Sandbox Forking",
+      "Usage with Truffle"
+    ],
     "Deployments": [
       "About Deployments",
       "Deploying Contracts",

--- a/src/docs/teams/sandboxes/creating-a-sandbox.md
+++ b/src/docs/teams/sandboxes/creating-a-sandbox.md
@@ -1,0 +1,14 @@
+---
+title: Teams | Creating a sandbox
+layout: docs.hbs
+---
+# Creating a sandbox
+
+Creating a sandbox is as easy as clicking <span class="inline-button">NEW SANDBOX</span>.
+
+<figure class="screenshot">
+  <img class="w-100" src="/img/docs/teams/sandboxes.png" alt="Truffle Teams SANDBOXES screen">
+  <figcaption class="text-center">The Truffle Teams Sandboxes screen.</figcaption>
+</figure>
+
+You'll see all the details necessary to start using this sandbox, including the `mnemonic` and `network_id`. Want to use sandboxes with Truffle? See the <a href="/docs/teams/sandboxes/usage-with-truffle">Usage with Truffle</a> documentation.

--- a/src/docs/teams/sandboxes/destroying-a-sandbox.md
+++ b/src/docs/teams/sandboxes/destroying-a-sandbox.md
@@ -1,0 +1,12 @@
+---
+title: Teams | Destroying a sandbox
+layout: docs.hbs
+---
+# Destroying a sandbox
+
+To destroy a sandbox, click <span class="inline-button red">DELETE</span> for the desired sandbox.
+
+<figure class="screenshot">
+  <img class="w-100" src="/img/docs/teams/sandboxes.png" alt="Truffle Teams SANDBOXES screen">
+  <figcaption class="text-center">The Truffle Teams Sandboxes screen.</figcaption>
+</figure>

--- a/src/docs/teams/sandboxes/renaming-a-sandbox.md
+++ b/src/docs/teams/sandboxes/renaming-a-sandbox.md
@@ -1,0 +1,12 @@
+---
+title: Teams | Renaming a sandbox
+layout: docs.hbs
+---
+# Renaming a sandbox
+
+By default, we generate a friendly name for each sandbox. To rename a sandbox, first click <span class="inline-button">VIEW/EDIT</span>. You'll see a modal with the sandbox details, including a text input with the name. Fill in the new name you would like and click <span class="inline-button">CONFIRM</span> to save the new name.
+
+<figure class="screenshot">
+  <img class="w-100" src="/img/docs/teams/sandboxes-02.png" alt="Rename a sandbox in Truffle Teams">
+  <figcaption class="text-center">The sandbox details modal.</figcaption>
+</figure>

--- a/src/docs/teams/sandboxes/sandbox-forking.md
+++ b/src/docs/teams/sandboxes/sandbox-forking.md
@@ -1,0 +1,18 @@
+---
+title: Teams | Sandbox forking
+layout: docs.hbs
+---
+# Sandbox forking
+
+Forking allows a sandbox to act as a live network from a given block number. We take for granted in web2 that we can get test credentials and interact with an API that will map to our production environment, but in web3 this hasn’t been so easy. With a forked sandbox you can transact, deploy, test, and debug against Mainnet without spending real Ether!
+
+<figure>
+  <img class="half-width mb-6" src="/img/docs/teams/what-is-forking.png" alt="Forking example">
+</figure>
+
+To fork a network, create a new sandbox by clicking the <span class="inline-button">NEW SANDBOX</span> button. Then, check the **Enable forking** checkbox. From there, select a network and optionally provide a block number. Clicking the <span class="inline-button">CONFIRM</span> button will spin up a new Ganache instance forked from the given network and block.
+
+<figure class="screenshot">
+  <img class="w-100" src="/img/docs/teams/sandbox-forking.png" alt="Sandbox forking options">
+  <figcaption class="text-center">Sandbox forking options and details.</figcaption>
+</figure>

--- a/src/docs/teams/sandboxes/sandboxes-overview.md
+++ b/src/docs/teams/sandboxes/sandboxes-overview.md
@@ -1,0 +1,9 @@
+---
+title: Teams | Sandboxes overview
+layout: docs.hbs
+---
+# Sandboxes overview
+
+Sandboxes are shared Ganache instances you can create with the click of a button. Convenient features of Ganache's local development experience are now available to the whole team! Each sandbox has 10 pre-funded accounts and near-instant transaction times giving your team a performant, turnkey blockchain environment without spending a single wei on transactions.
+
+Currently, sandboxes exist in isolation of the other features of Truffle Teams. Our next iteration will allow you to target a sandbox on the Deployments screen, as well as integrate with Monitoring. Sandboxes in Truffle Teams will also be the easiest way to use live chain data in your environment via forking.

--- a/src/docs/teams/sandboxes/usage-with-truffle.md
+++ b/src/docs/teams/sandboxes/usage-with-truffle.md
@@ -4,9 +4,21 @@ layout: docs.hbs
 ---
 # Usage with Truffle
 
-You can use sandboxes with all of Truffle's commands that work with Ganache, including: `migrate`, `console`, and `test`! Doing so requires a specific configuration of Truffle's HDWalletProvider.
+You can use sandboxes with all of Truffle's commands that work with Ganache, including: `migrate`, `console`, and `test`!
+With Truffle versions v5.1.28 and later, using a sandbox only requires the `url` field:
 
-In addition to providing the `mnemonic` and `network_id`, we must specify the initial account index (`0`), total number of accounts (`10`), and set the `shareNonce` option to `false`. Here's a complete example:
+```
+module.exports = {
+  networks: {
+    teams: {
+      url: "https://sandbox.truffleteams.com/ac98e539-140d-498e-818e-8284eee9d933",
+      network_id: 1583853263114
+    }
+  }
+};
+```
+
+If you're using an older version of truffle, You'll need to use HDWalletProvider. In addition to providing the `mnemonic` and `network_id`, we must specify the initial account index (`0`), total number of accounts (`10`), and set the `shareNonce` option to `false`. Here's a complete example:
 
 ```
 const HDWalletProvider = require("@truffle/hdwallet-provider");

--- a/src/docs/teams/sandboxes/usage-with-truffle.md
+++ b/src/docs/teams/sandboxes/usage-with-truffle.md
@@ -1,0 +1,25 @@
+---
+title: Teams | Usage with Truffle
+layout: docs.hbs
+---
+# Usage with Truffle
+
+You can use sandboxes with all of Truffle's commands that work with Ganache, including: `migrate`, `console`, and `test`! Doing so requires a specific configuration of Truffle's HDWalletProvider.
+
+In addition to providing the `mnemonic` and `network_id`, we must specify the initial account index (`0`), total number of accounts (`10`), and set the `shareNonce` option to `false`. Here's a complete example:
+
+```
+const HDWalletProvider = require("@truffle/hdwallet-provider");
+const teamsMnemonic = "custom buzz situate mesh cannon number grass improve iron swim pilot cool";
+
+module.exports = {
+  networks: {
+    teams: {
+      provider: function() {
+        return new HDWalletProvider(teamsMnemonic, "https://sandbox.truffleteams.com/ac98e539-140d-498e-818e-8284eee9d933", 0, 10, false);
+      },
+      network_id: 1583853263114
+    }
+  }
+};
+```


### PR DESCRIPTION
This PR adds a **Sandboxes** section with the following items in it, moved from the deployments section:
- [x] Sandboxes overview
- [x] Renaming a sandbox
- [x] Destroying a sandbox
- [x] Sandbox forking
- [x] Usage with Truffle

This PR cleans up any existing documentation per the style guide!