### PR TITLE
Elaborate on artifact json naming convetions.

### DIFF
--- a/src/docs/truffle/getting-started/compiling-contracts.md
+++ b/src/docs/truffle/getting-started/compiling-contracts.md
@@ -21,8 +21,7 @@ truffle compile
 Upon first run, all contracts will be compiled. Upon subsequent runs, Truffle will compile only the contracts that have been changed since the last compile. If you'd like to override this behavior, run the above command with the `--all` option.
 
 ## Build artifacts
-
-Artifacts of your compilation will be placed in the `build/contracts/` directory, relative to your project root. (This directory will be created if it does not exist.)
+Artifacts of your compilation will be placed in the `build/contracts/` directory, relative to your project root. (This directory will be created if it does not exist.) The name of the generated artifact `.json` files do **not reflect** the name of the **source file** but of the **name of the contract definition**. This means that changing the contract name string in the `artifacts.require` method to match that of the source file may lead to a `Error: Could not find artifacts for {yourContract} from any sources` if the contained smart contract definition is named differently.
 
 These artifacts are integral to the inner workings of Truffle, and they play an important part in the successful deployment of your application. **You should not edit these files** as they'll be overwritten by contract compilation and deployment.
 


### PR DESCRIPTION
Don't know if this extra notice is necessary, it's just that running `truffle test` wasn't working for some reason despite my source file being named correctly. My initial understanding was that artifact files are named after their source so I was sure that a typo wasn't the error. After a lot of debugging I realized that my contract was named differently and that that was the issue. In hindsight this fact is mentioned in the `running migrations` section of the docs but I feel I could've avoided the error if it was already mentioned in the `Compiling contracts` section.

*`TL;DR`* Despite this detail being mentioned in 'Running Migrations' I believe it should be mentioned again here since developers simply compiling and testing contracts may not necessarily deem it relevant to their issue to check in the 'Running Migrations' section.