### PR TITLE
docs: add deploymentPollingInterval to network config

### DIFF
--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -83,6 +83,7 @@ networks: {
     //          - if specified, host and port are ignored.
     // skipDryRun: - true if you don't want to test run the migration locally before the actual migration (default is false)
     // timeoutBlocks: - if a transaction is not mined, keep waiting for this number of blocks (default is 50)
+    // deploymentPollingInterval: - duration between checks for completion of deployment transactions
   }
 }
 ```
@@ -94,6 +95,7 @@ For each network, if unspecified, transaction options will default to the follow
 * `from`: From address used during migrations. Defaults to the first available account provided by your Ethereum client.
 * `provider`: Default web3 provider using `host` and `port` options: `new Web3.providers.HttpProvider("http://<host>:<port>")`
 * `websockets`: You will need this enabled to use the `confirmations` listener or to hear Events using `.on` or `.once`.  Default is `false`.
+* `deploymentPollingInterval`: When a smart contract is deployed, this determines how often to check whether the transaction has been completed, specified in milliseconds. Default is `4000`. Note that this is *independent* of the polling interval that `provider` may use. See [`@truffle/hdwallet-provider` documentation](https://github.com/trufflesuite/truffle/blob/develop/packages/hdwallet-provider/README.md#instantiation) if you are using `HDWalletProvider` and wish to specify a custom `pollingInterval`.
 
 For each network, you can specify `host` / `port`, `url`, or `provider`, but not more than one. If you need an HTTP provider, we recommend using `host` and `port`, or `url`, while if you need a custom provider such as `HDWalletProvider`, you must use `provider`.  The `url` option also supports WebSockets and SSL. `url` should include the full url; see the examples below:
 - http://127.0.0.1:8545


### PR DESCRIPTION
## What

- Document a way to reduce "chattiness" over JSON-RPC during deployment

## Why

- Documentation for new feature.

## Refs

- Directly related PR [#3517](https://github.com/trufflesuite/truffle/pull/3517)
- Indirectly related PR [#3499](https://github.com/trufflesuite/truffle/pull/3499)
- Partially resolves issue [#3948](https://github.com/trufflesuite/truffle/issues/3498)