### PR TITLE
Document recent additions to Truffle config

### DIFF
--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -84,6 +84,7 @@ networks: {
     // skipDryRun: - true if you don't want to test run the migration locally before the actual migration (default is false)
     // timeoutBlocks: - if a transaction is not mined, keep waiting for this number of blocks (default is 50)
     // deploymentPollingInterval: - duration between checks for completion of deployment transactions
+    // disableConfirmationListener: - true to disable web3's confirmation listener
   }
 }
 ```

--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -281,7 +281,7 @@ module.exports = {
   }
 }
 ```
-For more information, please see the Solidity documentation on [Compiler Input and Output JSON Description](http://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description) for the various possible settings.  Note that customizing `stopAfter` and `outputSelection` are not currently supported.
+For more information, please see the Solidity documentation on [Compiler Input JSON Description](https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description) for the various possible settings.  Note that customizing `stopAfter` and `outputSelection` are not currently supported.
 
 ### vyper
 
@@ -301,7 +301,7 @@ module.exports = {
 }
 ```
 
-Currently, only changing the `settings` is supported for Vyper, and customizing `outputSelection` is not supported, so the only option supported under `settings` is `evmVersion`.
+Currently, only changing the `settings` is supported for Vyper; see the Vyper documentation on [Compiler Input JSON Description](https://vyper.readthedocs.io/en/stable/compiling-a-contract.html#input-json-description) for the possible settings.  However customizing `outputSelection` is not supported, so currently the only supported setting is `evmVersion`.
 
 ### external compilers
 

--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -271,13 +271,34 @@ module.exports = {
           enabled: <boolean>,
           runs: <number>   // Optimize for how many times you intend to run the code
         },
-        evmVersion: <string> // Default: "petersburg"
+        evmVersion: <string> // Default: "istanbul"
       }
     }
   }
 }
 ```
-For more information, please see the Solidity documentation on [Compiler Input and Output JSON Description](http://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description).
+For more information, please see the Solidity documentation on [Compiler Input and Output JSON Description](http://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description); the various
+options under `settings` there can be used under `settings` here as well.
+
+### vyper
+
+Vyper compiler settings.  Similar to the `solc` settings, but not as extensive.  In particular, specifying a Vyper version is not currently supported; your local Vyper installation will always be used.
+
+Truffle config example:
+
+```javascript
+module.exports = {
+  compilers: {
+    vyper: {
+      settings: {
+        evmVersion: <string>
+      }
+    }
+  }
+}
+```
+
+Currently, only changing the `settings` is supported for Vyper, and the only option supported under `settings` is `evmVersion`.
 
 ### external compilers
 

--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -273,13 +273,15 @@ module.exports = {
           runs: <number>   // Optimize for how many times you intend to run the code
         },
         evmVersion: <string> // Default: "istanbul"
+      },
+      modelCheckerSettings: {
+        // contains options for SMTChecker
       }
     }
   }
 }
 ```
-For more information, please see the Solidity documentation on [Compiler Input and Output JSON Description](http://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description); the various
-options under `settings` there can be used under `settings` here as well.
+For more information, please see the Solidity documentation on [Compiler Input and Output JSON Description](http://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description) for the various possible settings.  Note that customizing `stopAfter` and `outputSelection` are not currently supported.
 
 ### vyper
 
@@ -299,7 +301,7 @@ module.exports = {
 }
 ```
 
-Currently, only changing the `settings` is supported for Vyper, and the only option supported under `settings` is `evmVersion`.
+Currently, only changing the `settings` is supported for Vyper, and customizing `outputSelection` is not supported, so the only option supported under `settings` is `evmVersion`.
 
 ### external compilers
 


### PR DESCRIPTION
This PR documents the recent additions to the Truffle config file.  Specifically:

* The Vyper settings (specifically `evmVersion`) from this PR: https://github.com/trufflesuite/truffle/pull/3568
* `viaIR` and `modelCheckerSettings` from this PR: https://github.com/trufflesuite/truffle/pull/3574
* The `disableConfirmationListener` option from this PR: https://github.com/trufflesuite/truffle/pull/3566

Note I did not document the old `sourceMap` option for Vyper since that's now gone as of [this PR](https://github.com/trufflesuite/truffle/pull/3572).

I'm not sure if I wrote the best description for `disableConfirmationListener`; @eggplantzzz, @gnidan, corrections are appreciated.