### PR TITLE
Document that in-test debugging currently doesn't work for reverted transactions

### DIFF
--- a/src/docs/truffle/getting-started/debugging-your-contracts.md
+++ b/src/docs/truffle/getting-started/debugging-your-contracts.md
@@ -64,6 +64,9 @@ for more information on `truffle test`, and see
 [Interacting with your contracts](/docs/truffle/getting-started/interacting-with-your-contracts)
 to learn about contract operations.
 
+**Note**: This feature currently doesn't work with reverted transactions;
+until we fix this, you can debug those with direct use of `truffle debug`.
+
 ### Debugging read-only calls
 
 Running the debugger from inside your JS tests allow additional functionality

--- a/src/docs/truffle/getting-started/debugging-your-contracts.md
+++ b/src/docs/truffle/getting-started/debugging-your-contracts.md
@@ -64,7 +64,7 @@ for more information on `truffle test`, and see
 [Interacting with your contracts](/docs/truffle/getting-started/interacting-with-your-contracts)
 to learn about contract operations.
 
-**Note**: This feature currently doesn't work with reverted transactions;
+**Note:** This feature currently doesn't work with reverted transactions;
 until we fix this, you can debug those with direct use of `truffle debug`.
 
 ### Debugging read-only calls


### PR DESCRIPTION
Redoes #863 with correct branch name this time. :)

Fixes https://github.com/trufflesuite/truffle/issues/3543.