### PR TITLE
replace getBalance with balanceOf

### DIFF
--- a/src/docs/truffle/testing/writing-tests-in-solidity.md
+++ b/src/docs/truffle/testing/writing-tests-in-solidity.md
@@ -27,7 +27,7 @@ contract TestMetaCoin {
 
     uint expected = 10000;
 
-    Assert.equal(meta.getBalance(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
+    Assert.equal(meta.balanceOf(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
   }
 
   function testInitialBalanceWithNewMetaCoin() {
@@ -35,7 +35,7 @@ contract TestMetaCoin {
 
     uint expected = 10000;
 
-    Assert.equal(meta.getBalance(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
+    Assert.equal(meta.balanceOf(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
   }
 }
 ```


### PR DESCRIPTION
In this documentation getBalance is used to get balance of a token. I suggest changing this to balanceOf as that is the function for getting balances from erc20 tokens which is likely a primary use base for tokens that may be tested like this.