### PR TITLE
Document new functionality of license option

### DIFF
--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -494,7 +494,8 @@ dependencies: {
 
 ### license
 
-License to use for this package. Strictly informative.
+License to use for this package; primarily informative.  Contracts created with `truffle create` will
+also include this in their `SPDX-License-Identifier` comment.
 
 Example:
 ```javascript


### PR DESCRIPTION
Documents the new functionality of the `license` config option added in [this PR](https://github.com/trufflesuite/truffle/pull/3507).