### PR TITLE
Update "contracts/Migrations.sol" code snippet

### DIFF
--- a/src/docs/truffle/getting-started/running-migrations.md
+++ b/src/docs/truffle/getting-started/running-migrations.md
@@ -82,6 +82,8 @@ pragma solidity >=0.4.22 <0.9.0;
 
 contract Migrations {
   address public owner = msg.sender;
+  
+  // A function with the signature `last_completed_migration()`, returning a uint, is required.
   uint public last_completed_migration;
 
   modifier restricted() {
@@ -91,7 +93,8 @@ contract Migrations {
     );
     _;
   }
-
+  
+  // A function with the signature `setCompleted(uint)` is required.
   function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;
   }

--- a/src/docs/truffle/getting-started/running-migrations.md
+++ b/src/docs/truffle/getting-started/running-migrations.md
@@ -78,30 +78,22 @@ Truffle requires you to have a Migrations contract in order to use the Migration
 Filename: `contracts/Migrations.sol`
 
 ```solidity
-pragma solidity ^0.4.8;
+pragma solidity >=0.4.22 <0.9.0;
 
 contract Migrations {
-  address public owner;
-
-  // A function with the signature `last_completed_migration()`, returning a uint, is required.
+  address public owner = msg.sender;
   uint public last_completed_migration;
 
   modifier restricted() {
-    if (msg.sender == owner) _;
+    require(
+      msg.sender == owner,
+      "This function is restricted to the contract's owner"
+    );
+    _;
   }
 
-  function Migrations() {
-    owner = msg.sender;
-  }
-
-  // A function with the signature `setCompleted(uint)` is required.
-  function setCompleted(uint completed) restricted {
+  function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;
-  }
-
-  function upgrade(address new_address) restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
   }
 }
 ```


### PR DESCRIPTION
Existing code snippet (pragma solidity 0.4.8) does not work anymore, due to error:

"Migrations.sol:13:3: Warning: This declaration shadows an existing declaration.
  function Migrations() {
  ^ (Relevant source part starts here and spans across multiple lines)."

My research says this is because function names are not allowed to share the same name as file name according to https://ethereum.stackexchange.com/questions/66104/solidity-code-compilation-error (which uses Solidity 0.5.0)

Regardless, the code snippet is supposed to come out of the box from truffle init. This boilerplate code has changed, I have simply provided the updated code.