### PR TITLE
Fix markdown to display hyperlinks for ganache docs

### DIFF
--- a/src/tutorials/chain-forking-exploiting-the-dao.md
+++ b/src/tutorials/chain-forking-exploiting-the-dao.md
@@ -1,6 +1,7 @@
-<p class="alert alert-info">
+<div class="alert alert-info">
+
 **Update**: Since this tutorial was published, we have released [Ganache](https://www.trufflesuite.com/docs/ganache/overview), a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Ganache Documentation](https://www.trufflesuite.com/ganache).
-</p>
+</div>
 
 Since The DAO [was exploited](http://hackingdistributed.com/2016/06/18/analysis-of-the-dao-exploit/), the Ethereum community has swarmed into action. From hardening our most popular language with the [latest Solidity release](https://github.com/ethereum/solidity/releases/tag/v0.4.0) to visualizing possible security vulnerabilities with [SolGraph](https://github.com/raineorshine/solgraph), the community has made security its number one focus. There are many ways in which to discover security threats, and most were discussed during Devcon 2 in Shanghai. The [ethereumjs-testrpc](https://github.com/ethereumjs/testrpc) authors have focused on one specifically, which we'll discuss here, called dynamic analysis through chain forking.
 

--- a/src/tutorials/chain-forking-exploiting-the-dao.md
+++ b/src/tutorials/chain-forking-exploiting-the-dao.md
@@ -1,6 +1,5 @@
 <div class="alert alert-info">
-
-**Update**: Since this tutorial was published, we have released [Ganache](https://www.trufflesuite.com/docs/ganache/overview), a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Ganache Documentation](https://www.trufflesuite.com/ganache).
+  <p class="mb-0"><strong>Update</strong>: Since this tutorial was published, we have released <a href="/docs/ganache/overview">Ganache</a>, a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our <a href="https://www.trufflesuite.com/ganache">Ganache Documentation</a></p>
 </div>
 
 Since The DAO [was exploited](http://hackingdistributed.com/2016/06/18/analysis-of-the-dao-exploit/), the Ethereum community has swarmed into action. From hardening our most popular language with the [latest Solidity release](https://github.com/ethereum/solidity/releases/tag/v0.4.0) to visualizing possible security vulnerabilities with [SolGraph](https://github.com/raineorshine/solgraph), the community has made security its number one focus. There are many ways in which to discover security threats, and most were discussed during Devcon 2 in Shanghai. The [ethereumjs-testrpc](https://github.com/ethereumjs/testrpc) authors have focused on one specifically, which we'll discuss here, called dynamic analysis through chain forking.

--- a/src/tutorials/ethereum-devops-truffle-testrpc-vsts.md
+++ b/src/tutorials/ethereum-devops-truffle-testrpc-vsts.md
@@ -1,6 +1,7 @@
-<p class="alert alert-info">
-**Update**: Since this tutorial was published, we have released [Ganache](/ganache) a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Working with Ganache](/docs/ganache/using) page.
-</p>
+<div class="alert alert-info">
+
+**Update**: Since this tutorial was published, we have released [Ganache](https://www.trufflesuite.com/docs/ganache/overview), a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Ganache Documentation](https://www.trufflesuite.com/ganache).
+</div>
 
 This post was originally published by David Burela on his blog [Burela's House-o-blog](https://davidburela.wordpress.com/2016/12/23/ethereum-devops-with-truffle-testrpc-visual-studio-team-services/). Big thanks to David for allowing us publish it here!
 

--- a/src/tutorials/ethereum-devops-truffle-testrpc-vsts.md
+++ b/src/tutorials/ethereum-devops-truffle-testrpc-vsts.md
@@ -1,6 +1,5 @@
 <div class="alert alert-info">
-
-**Update**: Since this tutorial was published, we have released [Ganache](https://www.trufflesuite.com/docs/ganache/overview), a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Ganache Documentation](https://www.trufflesuite.com/ganache).
+  <p class="mb-0"><strong>Update</strong>: Since this tutorial was published, we have released <a href="/docs/ganache/overview">Ganache</a>, a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our <a href="https://www.trufflesuite.com/ganache">Ganache Documentation</a></p>
 </div>
 
 This post was originally published by David Burela on his blog [Burela's House-o-blog](https://davidburela.wordpress.com/2016/12/23/ethereum-devops-with-truffle-testrpc-visual-studio-team-services/). Big thanks to David for allowing us publish it here!

--- a/src/tutorials/how-to-install-truffle-and-testrpc-on-windows-for-blockchain-development.md
+++ b/src/tutorials/how-to-install-truffle-and-testrpc-on-windows-for-blockchain-development.md
@@ -1,6 +1,7 @@
-<p class="alert alert-info">
-**Update**: Since this tutorial was published, we have released [Ganache](/ganache) a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Working with Ganache](/docs/ganache/using) page.
-</p>
+<div class="alert alert-info">
+
+**Update**: Since this tutorial was published, we have released [Ganache](https://www.trufflesuite.com/docs/ganache/overview), a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Ganache Documentation](https://www.trufflesuite.com/ganache).
+</div>
 
 This post was originally published by David Burela on his blog [Burela's House-o-blog](https://davidburela.wordpress.com/2016/11/18/how-to-install-truffle-testrpc-on-windows-for-blockchain-development/). Big thanks to David for allowing us publish it here!
 

--- a/src/tutorials/how-to-install-truffle-and-testrpc-on-windows-for-blockchain-development.md
+++ b/src/tutorials/how-to-install-truffle-and-testrpc-on-windows-for-blockchain-development.md
@@ -1,6 +1,5 @@
 <div class="alert alert-info">
-
-**Update**: Since this tutorial was published, we have released [Ganache](https://www.trufflesuite.com/docs/ganache/overview), a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Ganache Documentation](https://www.trufflesuite.com/ganache).
+  <p class="mb-0"><strong>Update</strong>: Since this tutorial was published, we have released <a href="/docs/ganache/overview">Ganache</a>, a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our <a href="https://www.trufflesuite.com/ganache">Ganache Documentation</a></p>
 </div>
 
 This post was originally published by David Burela on his blog [Burela's House-o-blog](https://davidburela.wordpress.com/2016/11/18/how-to-install-truffle-testrpc-on-windows-for-blockchain-development/). Big thanks to David for allowing us publish it here!

--- a/src/tutorials/truffle-and-metamask.md
+++ b/src/tutorials/truffle-and-metamask.md
@@ -1,6 +1,7 @@
-<p class="alert alert-info">
-**Update**: Since this tutorial was published, we have released [Ganache](/ganache) a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but for the most up-to-date information on using Truffle with Metamask, we highly recommend checking out [our documentation](/docs/advanced/truffle-with-metamask).
-</p>
+<div class="alert alert-info">
+
+**Update**: Since this tutorial was published, we have released [Ganache](https://www.trufflesuite.com/docs/ganache/overview), a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Ganache Documentation](https://www.trufflesuite.com/ganache).
+</div>
 
 This article was originally written by Dan Finlay and published as a [github gist](https://gist.github.com/flyswatter/aea93752fb90322bbe11). Dan has kindly allowed us to republish it here!
 

--- a/src/tutorials/truffle-and-metamask.md
+++ b/src/tutorials/truffle-and-metamask.md
@@ -1,6 +1,5 @@
 <div class="alert alert-info">
-
-**Update**: Since this tutorial was published, we have released [Ganache](https://www.trufflesuite.com/docs/ganache/overview), a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our [Ganache Documentation](https://www.trufflesuite.com/ganache).
+  <p class="mb-0"><strong>Update</strong>: Since this tutorial was published, we have released <a href="/docs/ganache/overview">Ganache</a>, a personal blockchain and a replacement to the TestRPC. We have left this tutorial unaltered, but we highly recommend checking out our <a href="https://www.trufflesuite.com/ganache">Ganache Documentation</a></p>
 </div>
 
 This article was originally written by Dan Finlay and published as a [github gist](https://gist.github.com/flyswatter/aea93752fb90322bbe11). Dan has kindly allowed us to republish it here!


### PR DESCRIPTION
This PR changes the `p` tag to be a `div` and puts a space below the opening div tag in order for the hyperlinks to ganache to render properly. 