### PR TITLE
Update Tezos support documentation for delphinet

### DIFF
--- a/src/docs/tezos/truffle/getting-started/deploying-tezos-contracts.md
+++ b/src/docs/tezos/truffle/getting-started/deploying-tezos-contracts.md
@@ -120,8 +120,8 @@ To conditionally stage deployment steps, write your migrations so that they acce
 
 ```javascript
 module.exports = function(deployer, network) {
-  if (network == "carthagenet") {
-    // Do something specific to the network named "carthagenet".
+  if (network == "delphinet") {
+    // Do something specific to the network named "delphinet".
   } else {
     // Perform a different step otherwise.
   }

--- a/src/docs/tezos/truffle/quickstart.md
+++ b/src/docs/tezos/truffle/quickstart.md
@@ -68,11 +68,11 @@ You can see that these contracts end in the `.ligo` file extension. This refers 
 
 ## Deploying Contracts
 
-For this quick start, we're going to configure your project to deploy to the [Carthagenet](https://tezos.gitlab.io/introduction/test_networks.html#carthagenet) test network for Tezos. This is the quickest way to get started, though as you get familiar with Tezos, you'll want to set up a local development environment. See the [example box documentation](https://github.com/truffle-box/tezos-example-box#sandbox-management) for an example on using a local flextesa sandbox.
+For this quick start, we're going to configure your project to deploy to [Delphinet](https://tezos.gitlab.io/introduction/test_networks.html#delphinet) or any other existing [test network](https://tezos.gitlab.io/introduction/test_networks.html) for Tezos. This is the quickest way to get started, though as you get familiar with Tezos, you'll want to set up a local development environment. See the [example box documentation](https://github.com/truffle-box/tezos-example-box#sandbox-management) for an example on using a local flextesa sandbox.
 
-### Configuring Truffle to point to the Carthage testnet
+### Configuring Truffle to point to the Tezos testnet
 
-First, navigate to [https://faucet.tzalpha.net/](https://faucet.tzalpha.net/) to get a faucet account. This will create a new account for you on the testnet and fill it with some testnet XTZ. Download the file and save it as `faucet.json` in the root of your project.
+First, navigate to [https://faucet.tzalpha.net/](https://faucet.tzalpha.net/) to get a faucet account. This will create a new account for you on the testnet and fill it with some testnet XTZ. This account is valid for all the Tezos test networks. Download the file and save it as `faucet.json` in the root of your project.
 
 Next, replace the box's `truffle-config.js` with the following: 
 
@@ -84,7 +84,7 @@ module.exports = {
   // for more details on how to specify configuration options!
   networks: {
     development: {
-      host: "https://carthagenet.smartpy.io",
+      host: "https://delphinet.smartpy.io",
       port: 443,
       network_id: "*",
       secret,
@@ -136,7 +136,7 @@ Running your tests is easy, by running following command:
 
 ## Further Resources
 
-If you've reached this point, you now have a Truffle project that lets you compile, test, and deploy LIGO contracts to the Carthage Tezos test network. Congrats! This is a great start, but there's still much to learn. We suggest you check out the following resources to learn more about Tezos, LIGO, and Truffle:
+If you've reached this point, you now have a Truffle project that lets you compile, test, and deploy LIGO contracts to the Tezos test network. Congrats! This is a great start, but there's still much to learn. We suggest you check out the following resources to learn more about Tezos, LIGO, and Truffle:
 
 * [LIGO language documentation](https://ligolang.org/docs/intro/introduction/)
 * [Tezos documentation](https://tezos.gitlab.io/)

--- a/src/docs/tezos/truffle/quickstart.md
+++ b/src/docs/tezos/truffle/quickstart.md
@@ -68,7 +68,7 @@ You can see that these contracts end in the `.ligo` file extension. This refers 
 
 ## Deploying Contracts
 
-For this quick start, we're going to configure your project to deploy to [Delphinet](https://tezos.gitlab.io/introduction/test_networks.html#delphinet) or any other existing [test network](https://tezos.gitlab.io/introduction/test_networks.html) for Tezos. This is the quickest way to get started, though as you get familiar with Tezos, you'll want to set up a local development environment. See the [example box documentation](https://github.com/truffle-box/tezos-example-box#sandbox-management) for an example on using a local flextesa sandbox.
+For this quick start, we're going to configure your project to deploy to the [Delphinet](https://tezos.gitlab.io/introduction/test_networks.html#delphinet) or any other existing [test network](https://tezos.gitlab.io/introduction/test_networks.html) for Tezos. This is the quickest way to get started, though as you get familiar with Tezos, you'll want to set up a local development environment. See the [example box documentation](https://github.com/truffle-box/tezos-example-box#sandbox-management) for an example on using a local flextesa sandbox.
 
 ### Configuring Truffle to point to the Tezos testnet
 

--- a/src/docs/tezos/truffle/quickstart.md
+++ b/src/docs/tezos/truffle/quickstart.md
@@ -72,7 +72,7 @@ For this quick start, we're going to configure your project to deploy to the [De
 
 ### Configuring Truffle to point to the Tezos testnet
 
-First, navigate to [https://faucet.tzalpha.net/](https://faucet.tzalpha.net/) to get a faucet account. This will create a new account for you on the testnet and fill it with some testnet XTZ. This account is valid for all the Tezos test networks. Download the file and save it as `faucet.json` in the root of your project.
+First, navigate to [https://faucet.tzalpha.net/](https://faucet.tzalpha.net/) to get a faucet account. This will create a new account for you on the testnet and fill it with some testnet XTZ. This account is valid for all Tezos test networks. Download the file and save it as `faucet.json` in the root of your project.
 
 Next, replace the box's `truffle-config.js` with the following: 
 

--- a/src/docs/tezos/truffle/reference/configuring-tezos-projects.md
+++ b/src/docs/tezos/truffle/reference/configuring-tezos-projects.md
@@ -21,7 +21,7 @@ module.exports = {
   // for more details on how to specify configuration options!
   networks: {
     development: {
-      host: "https://carthagenet.smartpy.io",
+      host: "https://delphinet.smartpy.io",
       port: 443,
       network_id: "*",
       secret,
@@ -36,7 +36,7 @@ module.exports = {
 
 ## Configuring your project to deploy to a public test network
 
-The above configuration defines a single development network pointed at the public [CarthageNet](https://tezos.gitlab.io/introduction/test_networks.html) test network. You can see how this is set up in context by following our [quickstart](/docs/tezos/truffle/quickstart).
+The above configuration defines a single development network pointed at the public [Delphinet](https://tezos.gitlab.io/introduction/test_networks.html) test network. You can see how this is set up in context by following our [quickstart](/docs/tezos/truffle/quickstart).
 
 Developing on public test nets can be limiting for a number of reasons (acquiring test net tokens, performance, and internet connectivity, among others). Fortunately, there's a local solution.
 
@@ -64,7 +64,7 @@ The `networks` object, shown below, is keyed by a network name and contains a co
 The network name is used for user interface purposes, such as when running your migrations on a specific network:
 
 ```shell
-$ truffle migrate --network carthagenet
+$ truffle migrate --network delphinet
 ```
 
 Example:
@@ -72,13 +72,13 @@ Example:
 ```javascript
 networks: {
   development: {
-    host: "https://carthagenet.smartpy.io",
+    host: "https://delphinet.smartpy.io",
     port: 443,
     network_id: "*",
     type: "tezos"
   },
-  carthagenet: {
-    host: "https://carthagenet.smartpy.io",
+  delphinet: {
+    host: "https://delphinet.smartpy.io",
     port: 443,
     network_id: "*",
     type: "tezos"


### PR DESCRIPTION
This PR updates Carthagenet network mentions to Delphinet.

It also provides some clues for the user to understand that a different test network can be used if Delphinet is disabled at some point.