### PR TITLE
Fix unterminated string in require statement

### DIFF
--- a/src/blog/a-sweet-upgradeable-contract-experience-with-openzeppelin-and-truffle.md
+++ b/src/blog/a-sweet-upgradeable-contract-experience-with-openzeppelin-and-truffle.md
@@ -28,7 +28,7 @@ npm install --save-dev @openzeppelin/truffle-upgrades
 Then, in your migration script, use the new deployProxy and upgradeProxy functions:
 
 ```javascript
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades);
+const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const Box = artifacts.require('Box');
 const BoxV2 = artifacts.require('BoxV2');


### PR DESCRIPTION
Contributing a small typo fix in the documentation around using `@openzeppelin/truffle-upgrades`.

Happy to make any requested changes, I have read the contribution guidelines. I assumed that the branch should be `content` rather than `fix` because the issue is with a code sample inside of a blog post, rather than any of the code used by the website itself.