### PR TITLE
Chore/quick ganache fixes

### DIFF
--- a/src/docs/data.json
+++ b/src/docs/data.json
@@ -1,9 +1,6 @@
 {
   "teams": {
-    "Getting Started": [
-      "Creating an account",
-      "Adding repositories"
-    ],
+    "Getting Started": ["Creating an account", "Adding repositories"],
     "Account": [
       "Manage your account",
       "Switching accounts",
@@ -50,13 +47,8 @@
       "Adding a deployment",
       "Switching deployments"
     ],
-    "Reference": [
-      "Configuration",
-      "Permissions disclosure"
-    ],
-    "Support": [
-      "Ask us a question"
-    ]
+    "Reference": ["Configuration", "Permissions disclosure"],
+    "Support": ["Ask us a question"]
   },
   "truffle": {
     "Getting Started": [
@@ -99,6 +91,7 @@
   "ganache": {
     "Workspaces": [
       "The Quickstart Workspace",
+      "Ethereum Workspace Overview",
       "Creating Workspaces",
       "Loading Existing Workspaces",
       "Switching Workspaces",
@@ -122,20 +115,11 @@
       "CorDapps",
       "Shell"
     ],
-    "Reference": [
-      "Ganache Settings",
-      "Workspace Default Configuration"
-    ]
+    "Reference": ["Ganache Settings", "Workspace Default Configuration"]
   },
   "drizzle": {
-    "Getting Started": [
-      "Using Drizzle's Redux Store",
-      "Contract Interaction"
-    ],
-    "React": [
-      "React Integration",
-      "React Components"
-    ],
+    "Getting Started": ["Using Drizzle's Redux Store", "Contract Interaction"],
+    "React": ["React Integration", "React Components"],
     "Reference": [
       "Drizzle Options",
       "Drizzle State",
@@ -156,9 +140,7 @@
         "Using the Console with Tezos",
         "Writing External Scripts with Tezos"
       ],
-      "Reference": [
-        "Configuring Tezos Projects"
-      ]
+      "Reference": ["Configuring Tezos Projects"]
     }
   }
 }

--- a/src/docs/ganache/overview.md
+++ b/src/docs/ganache/overview.md
@@ -2,6 +2,7 @@
 title: Ganache | Overview
 layout: docs.hbs
 ---
+
 <img style="max-width: 160px;" src="/img/ganache-logo-dark.svg" alt="Ganache Logo" />
 
 <div class="text-center docs-badges">
@@ -16,4 +17,6 @@ layout: docs.hbs
 
 [Ganache](/ganache) is a personal blockchain for rapid Ethereum and Corda distributed application development. You can use Ganache across the entire development cycle; enabling you to develop, deploy, and test your dApps in a safe and deterministic environment.
 
-Ganache UI is desktop application supporting both Ethereum and Corda technology. In addition, an Ethereum version of ganache is available as a command-line tool: [ganache-cli](https://github.com/trufflesuite/ganache-cli) (formerly known as the TestRPC). All versions of Ganache are available for Windows, Mac, and Linux.
+Ganache comes in two flavors: a UI and CLI. Ganache UI is a desktop application supporting both Ethereum and Corda technology. The command-line tool, [ganache-cli](https://github.com/trufflesuite/ganache-cli) (formerly known as the TestRPC), is available for Ethereum development. Prefer using the command-line? This documentation will focus only on the UI flavor of Ganache. Please see the [Ganache CLI Readme](https://github.com/trufflesuite/ganache-cli/blob/master/README.md) for command-line documentation.
+
+All versions of Ganache are available for Windows, Mac, and Linux.

--- a/src/docs/ganache/quickstart.md
+++ b/src/docs/ganache/quickstart.md
@@ -2,6 +2,7 @@
 title: Ganache | Ganache Quickstart
 layout: docs.hbs
 ---
+
 # Ganache Quickstart
 
 This quickstart guide will walk you through installing Ganache and creating a personal development blockchain via a quickstart workspace.
@@ -16,9 +17,9 @@ If this isn't your first time using Ganache, or you already know you'll need cus
 
 [Download](https://github.com/trufflesuite/ganache/releases) the appropriate version for your OS:
 
-* Windows: `Ganache-*.appx`
-* Mac: `Ganache-*.dmg`
-* Linux: `ganache-*.AppImage`
+- Windows: `Ganache-*.appx`
+- Mac: `Ganache-*.dmg`
+- Linux: `ganache-*.AppImage`
 
 Next, double-click on the downloaded file, follow the prompts, and you're up and running.
 
@@ -34,5 +35,5 @@ When you open Ganache for the first time, you'll see the home screen. On this sc
 
 Now that you've got a workspace created, let's take a look at what you can do:
 
- * **[Ethereum workspace overview](./workspaces/ethereum)**
- * **[Corda workspace overview](./corda/workspace-overview)**
+- **[Ethereum workspace overview](./workspaces/ethereum-workspace-overview)**
+- **[Corda workspace overview](./corda/workspace-overview)**

--- a/src/docs/ganache/reference/ganache-settings.md
+++ b/src/docs/ganache/reference/ganache-settings.md
@@ -2,27 +2,35 @@
 title: Ganache | Ganache Settings
 layout: docs.hbs
 ---
+
 # Ganache Settings
 
 You can change some features of the generated blockchain through the **Settings** pages, accessed by the gear icon in the top right corner. You'll also be prompted with the settings screen when created a [New Workspace](/docs/ganache/workspaces/creating-workspaces).
+
+The settings page will vary depending on whether you're developing on [Ethereum](#ethereum) or [Corda](#corda). After updating your settings, don't forget to [save your changes](#save-your-changes).
 
 ![Accessing Ganache Settings](/img/docs/ganache/ganache-settings-gear-icon.png)
 
 <p class="text-center">*Accessing Ganache Settings*</p>
 
-We've divided the settings into several pages:
+## Ethereum
 
-* **Workspace** sets the workspace name and shows the currently linked Truffle or Corda projects. See our more detailed docs on [creating](/docs/ganache/workspaces/creating-workspaces) and [deleting](/docs/ganache/workspaces/deleting-workspaces) workspaces for more info.
-* **Ethereum**
-  * **Server** shows details about the network connection, including hostname, port, network ID, and whether to automatically mine each transaction into a block.
-  * **Accounts & Keys** sets details about the number of accounts created, and whether to use a specific mnemonic or let Ganache generate its own.
-  * **Chain** sets configuration details for the genesis and parameters of the generated blockchain, including gas limit and gas price.
-  * **Advanced** toggles Google Analytics, which is useful for the Ganache team to track usage of the application.
-* **Corda**
-  * **Nodes** manages the nodes for the network.
-  * **Notaries** manages the notaries for the network.
-  * **Advanced** sets the default PostgreSQL port and toggles Google Analytics, which is useful for the team to improve Ganache based on anonymous usage metrics.
-* **About** contains information on the currently installed version of Ganache, along with links to our website and the [Ganache GitHub repository](https://github.com/trufflesuite/ganache).
+- **Workspace** sets the workspace name and shows the currently linked Truffle projects. See our more detailed docs on [creating](/docs/ganache/workspaces/creating-workspaces) and [deleting](/docs/ganache/workspaces/deleting-workspaces) workspaces for more info.
+- **Server** shows details about the network connection, including hostname, port, network ID, and whether to automatically mine each transaction into a block. These connection details need to match your [Truffle configuration](#configuring-truffle-to-connect-to-ganache).
+- **Accounts & Keys** sets details about the number of accounts created, and whether to use a specific mnemonic or let Ganache generate its own.
+- **Chain** sets configuration details for the genesis and parameters of the generated blockchain, including gas limit and gas price.
+- **Advanced** toggles Google Analytics, which is useful for the Ganache team to track usage of the application.
+- **About** contains information on the currently installed version of Ganache, along with links to our website and the [Ganache GitHub repository](https://github.com/trufflesuite/ganache).
+
+## Corda
+
+- **Workspace** sets the workspace name and shows the currently linked Corda projects. See our more detailed docs on [creating](/docs/ganache/workspaces/creating-workspaces) and [deleting](/docs/ganache/workspaces/deleting-workspaces) workspaces for more info.
+- **Nodes** manages the nodes for the network.
+- **Notaries** manages the notaries for the network.
+- **Advanced** sets the default PostgreSQL port and toggles Google Analytics, which is useful for the team to improve Ganache based on anonymous usage metrics.
+- **About** contains information on the currently installed version of Ganache, along with links to our website and the [Ganache GitHub repository](https://github.com/trufflesuite/ganache).
+
+## Save your changes
 
 After making changes, you will have to click **Restart** on the application for the changes to take effect.
 

--- a/src/docs/ganache/workspaces/ethereum-workspace-overview.md
+++ b/src/docs/ganache/workspaces/ethereum-workspace-overview.md
@@ -15,12 +15,12 @@ Once you've created a workspace, the screen will show some details about the ser
 
 There are six pages available:
 
-* **Accounts** shows the accounts generated and their balances. This is the default view.
-* **Blocks** shows each block as mined on the blockchain, along with gas used and transactions.
-* **Transactions** lists all transactions run against the blockchain.
-* **Contracts** lists the contracts contained in your workspace's Truffle projects. For more information on how Ganache handles contracts, see our [Contracts Page documentation](/docs/ganache/truffle-projects/contracts-page).
-* **Events** lists all events that have been triggered since this workspace's creation. Ganache will attempt to decode events triggered by contracts in your Truffle project. For more information on events, see our [Events Page documentation](/docs/ganache/truffle-projects/events-page).
-* **Logs** shows the logs for the server, which is useful for debugging.
+- **Accounts** shows the accounts generated and their balances. This is the default view.
+- **Blocks** shows each block as mined on the blockchain, along with gas used and transactions.
+- **Transactions** lists all transactions run against the blockchain.
+- **Contracts** lists the contracts contained in your workspace's Truffle projects. For more information on how Ganache handles contracts, see our [Contracts Page documentation](/docs/ganache/truffle-projects/contracts-page).
+- **Events** lists all events that have been triggered since this workspace's creation. Ganache will attempt to decode events triggered by contracts in your Truffle project. For more information on events, see our [Events Page documentation](/docs/ganache/truffle-projects/events-page).
+- **Logs** shows the logs for the server, which is useful for debugging.
 
 Also note that you can search for block numbers or transaction hashes from a search box at the top.
 


### PR DESCRIPTION
This PR addresses part of [Roadmap Issue #321](https://app.zenhub.com/workspaces/batches-5ff34ea73ec4eb001f03e928/issues/trufflesuite/roadmap/321)

Included are just a few quick fixes:
- [x] add link to ganache-cli docs in the overview
- [x] make ethereum workspace overview easily accessible
- [x] update settings section to be divided by flavor (ethereum or corda)