### PR TITLE
Add documentation for "truffle preserve"

### DIFF
--- a/src/docs/data.json
+++ b/src/docs/data.json
@@ -70,7 +70,8 @@
       "Package Management via NPM",
       "Debugging Your Contracts",
       "Using Truffle Develop and The Console",
-      "Writing External Scripts"
+      "Writing External Scripts",
+      "Preserving Files and Content to Storage Platforms"
     ],
     "Testing": [
       "Testing Your Contracts",

--- a/src/docs/filecoin/truffle/quickstart.md
+++ b/src/docs/filecoin/truffle/quickstart.md
@@ -3,10 +3,6 @@ title: Truffle | Filecoin Quickstart
 layout: docs.hbs
 ---
 
-<p class="alert alert-danger">
-<strong>Filecoin support</strong> in Truffle is experimental. Give it a spin, and help us out by <a href="https://github.com/trufflesuite/truffle/issues">filing issues on Github</a>.
-</p>
-
 # Filecoin Quickstart
 
 Wanna build apps on Filecoin using Truffle? You're in the right place.
@@ -31,13 +27,9 @@ Looking to set up Filecoin-flavored Ganache? Head over to the [Ganache-specific 
 
 ## Installing Truffle
 
-<!-- TODO: Mike just replaced Tezos with Filecoin; Rosco/gnidan may need to update the below -->
+Truffle's Filecoin integration works out of the box with the latest Truffle, so no need to install any special versions for it.
 
-You'll need to download a special version of Truffle to use Filecoin.
-
-    $ npm install -g truffle@filecoin
-
-If you already have Truffle installed, we recommend uninstalling truffle before running the above command.
+    $ npm install -g truffle
 
 ## Using the Filecoin Truffle Box
 
@@ -49,9 +41,21 @@ In your workspace directory, run the following commands:
     $ cd filecoin-example
     $ truffle unbox filecoin
 
-## Further Resources
+More specific usage information about the Filecoin Truffle Box can be found in its [README](https://github.com/truffle-box/filecoin-box).
 
-<!-- TODO: Below may need some Truffle-specific modification from Rosco/gnidan -->
+## Preserving files to IPFS and Filecoin
+
+Truffle offers builtin functionality to preserve any files and directories to IPFS, Filecoin or Textile Buckets through the `truffle preserve` command. This works with local IPFS / Filecoin nodes, remote nodes and Filecoin-flavored Ganache! Besides this, `truffle preserve` also has support for [Textile Buckets](https://docs.textile.io/buckets/), which offers a smooth user experience around IPFS and Filecoin.
+
+```shell
+$ truffle preserve ./stuff --ipfs
+$ truffle preserve ./stuff --filecoin
+$ truffle preserve ./stuff --buckets
+```
+
+For extensive documentation on `truffle preserve` refer to the [main Truffle documentation](/docs/truffle/getting-started/preserving-files-and-content-to-storage-platforms).
+
+## Further Resources
 
 If you've reached this point, you now have a Truffle project that lets you interact with the Filecoin network. Congrats! This is a great start, but there's still much to learn. We suggest you check out the following resources to learn more about Filecoin, Textile, Ganache, and the entire Truffle Suite:
 

--- a/src/docs/truffle/getting-started/preserving-files-and-content-to-storage-platforms.md
+++ b/src/docs/truffle/getting-started/preserving-files-and-content-to-storage-platforms.md
@@ -1,0 +1,144 @@
+---
+title: Truffle | Preserving Files and Content to Storage Platforms
+layout: docs.hbs
+---
+# Preserving Files and Content to Storage Platforms
+
+## Preserving to IPFS, Filecoin or Textile Buckets
+
+The [`truffle preserve` command](/docs/truffle/reference/truffle-commands#preserve) comes preconfigured with the ability to preserve files to IPFS, Filecoin or Textile Buckets.
+
+### IPFS
+
+To preserve your files to IPFS use the `--ipfs` flag.
+
+```shell
+$ truffle preserve ./path --ipfs [--environment <name>]
+```
+
+#### Configuration
+
+By default, the connection to IPFS is done with a local node presumed to be running at `http://localhost:5001`. This is the default for an `ipfs` daemon and also for `ganache filecoin`. It is possible to point to a different IPFS node by configuing a different URL in a `truffle-config.js` environment.
+
+```javascript
+module.exports = {
+  /* ... rest of truffle-config */
+
+  environments: {
+    /* ... other environments */
+
+    production: {
+      ipfs: {
+        address: 'https://ipfs.infura.io:5001'
+      }
+    }
+  }
+}
+```
+
+### Filecoin
+
+To preserve your files to Filecoin use the `--filecoin` flag.
+
+```shell
+$ truffle preserve ./path --filecoin [--environment <name>]
+```
+
+#### Configuration
+
+By default, the connection to Filecoin is done with a local node presumed to be running at `http://localhost:7777/rpc/v0`. This is the default for a mainnet or localnet Lotus or Powergate node and also for `ganache filecoin`. It is possible to point to a different Filecoin node by configuing a different URL in a `truffle-config.js` environment. Besides the connection URL, you can also configure Filecoin storage deal options such as the duration or price.
+
+```javascript
+module.exports = {
+  /* ... rest of truffle-config */
+
+  environments: {
+    /* ... other environments */
+
+    development: {
+      filecoin: {
+        address: 'http://localhost:1234/rpc/v0',
+        token: 'AUTH_TOKEN',
+        storageDealOptions: {
+          epochPrice: "2500",
+          duration: 518400, // 180 days
+        }
+      }
+    }
+  }
+}
+```
+
+### Textile Buckets
+
+To preserve your files to Textile Buckets use the `--buckets` flag.
+
+```shell
+$ truffle preserve ./path --buckets [--environment <name>]
+```
+
+#### Configuration
+
+Textile Buckets requires some configuration in order to work with `truffle preserve`. To get started, you need to install [Textile's `hub` tool](https://docs.textile.io/hub/), register and create authentication keys.
+
+```shell
+hub init
+hub keys create
+ - account
+ - Require Signature Authentication (recommended): N
+```
+
+After generating these keys, they need to be added to an environment in your `truffle-config.js` file as well as the name of the bucket that you want to preserve your files to - it's possible to use an existing bucket for this, or if it doesn't exist yet it will be created in the process.
+
+```javascript
+module.exports = {
+  /* ... rest of truffle-config */
+
+  environments: {
+    /* ... other environments */
+
+    development: {
+      buckets: {
+        key: "MY_BUCKETS_KEY",
+        secret: "MY_BUCKETS_SECRET",
+        bucketName: "truffle-preserve-bucket",
+      }
+    }
+  }
+}
+```
+
+## Preserving with custom preserve recipes
+
+While Truffle comes bundled with support for IPFS, Filecoin and Textile Buckets, additional workflows (or recipes) can be defined and used.
+
+### Plugin installation / configuration
+
+1. Install the plugin from NPM.
+  ```shell
+  npm install --save-dev truffle-preserve-to-my-server
+  ```
+
+2. Add a `plugins` section to your Truffle config.
+  ```javascript
+  module.exports = {
+    /* ... rest of truffle-config */
+
+    plugins: [
+      "truffle-preserve-to-my-server"
+    ]
+  }
+  ```
+
+3. Add any required configuration options to your Truffle config if it's required by the plugin. Refer to the plugin's documentation for this.
+
+### Plugin usage
+
+After installation and configuration, the plugin's tag (e.g. `--my-server`) will show up in `truffle help preserve` and can be used with `truffle preserve`.
+
+```shell
+truffle preserve ./path --my-server
+```
+
+## Creating custom preserve recipes
+TODO: Add a link to the typedoc here and refer to existing plugins as example.

--- a/src/docs/truffle/getting-started/preserving-files-and-content-to-storage-platforms.md
+++ b/src/docs/truffle/getting-started/preserving-files-and-content-to-storage-platforms.md
@@ -141,4 +141,9 @@ truffle preserve ./path --my-server
 ```
 
 ## Creating custom preserve recipes
-TODO: Add a link to the typedoc here and refer to existing plugins as example.
+Refer to the following resources to get started creating your own custom recipes:
+
+- [@truffle/preserve Typedocs](/docs/truffle/preserve)
+- [@truffle/preserve-to-ipfs source code](https://github.com/trufflesuite/truffle/tree/develop/packages/preserve-to-ipfs)
+- [@truffle/preserve-to-filecoin source code](https://github.com/trufflesuite/truffle/tree/develop/packages/preserve-to-filecoin)
+- [@truffle/preserve-to-buckets source code](https://github.com/trufflesuite/truffle/tree/develop/packages/preserve-to-buckets)

--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -423,10 +423,32 @@ know how we can improve it!
 Provides Truffle with a list of installed third-party extensions installed as
 NPM package dependencies.
 
-Truffle plugin support is currently limited to plugins that define custom
-workflow commands. For more information, see [Third-Party Plugin Commands](/docs/truffle/getting-started/writing-external-scripts#third-party-plugin-commands).
+Truffle supports two separate kinds of plugins. The first are `run` plugins that define a custom workflow command. More information on these can be found under [Third-Party Plugin Commands](/docs/truffle/getting-started/writing-external-scripts#third-party-plugin-commands). The second type of plugins are `preserve` plugins that define a custom workflow for preserving content using the `truffle preserve` command. More information on these can be found under [Preserving Files and Content to Storage Platforms](/docs/truffle/getting-started/preserving-files-and-content-to-storage-platforms).
 
+## Environments
 
+Environments are a way to specify different configuration parameters depending on the selected environment. For example, connection to IPFS is often done with a local node or ganache, while in production, it makes sense to connect to Infura. This can be configured with environments.
+
+```js
+module.exports = {
+  /* ... rest of truffle-config */
+
+  environments: {
+    /* ... other environments */
+
+    development: {
+      ipfs: {
+        address: 'http://localhost:5001
+      }
+    },
+    production: {
+      ipfs: {
+        address: 'https://ipfs.infura.io:5001'
+      }
+    }
+  }
+}
+```
 
 ## EthPM configuration
 

--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -283,6 +283,25 @@ Option:
 * `<contract_name>`: Name of the contract to print opcodes for. Must be a contract name, not a file name. (required)
 
 
+### preserve
+
+Preserve files and content to decentralised storage platforms such as IPFS or Filecoin.
+
+```shell
+truffle preserve <path> --<recipe> [--environment <name>]
+```
+
+Options:
+
+* `--ipfs`: Preserve files to IPFS
+* `--filecoin`: Preserve files to Filecoin
+* `--buckets`: Preserve files to Textile Buckets
+* `--<recipe>`: Preserve files using an installed plugin with the specified recipe tag
+* `--environment <name>`: Specify the environment to use (defined in `truffle-config.js`) (default: "development")
+
+Custom options for these "preserve recipes" can be provided through [environments](/docs/truffle/reference/configuration#environments). Additional preserve recipes can be installed through NPM and [configured as Truffle plugins](/docs/truffle/reference/configuration#plugins). More information about usage, configuration and installation of preserve recipes can be found on the [dedicated documentation page](/docs/truffle/getting-started/preserving-files-and-content-to-storage-platforms).
+
+
 ### publish
 
 Publish a package to the Ethereum Package Registry.


### PR DESCRIPTION
- Add separate page to "Getting Started"
- Add note about "preserve" plugins as opposed to "run" plugins
- Add section about truffle-config environments
- Add section about the "preserve" command to reference
- Slightly expand Filecoin docs section