### PR TITLE
Update running-migrations.md

### DIFF
--- a/src/docs/truffle/getting-started/running-migrations.md
+++ b/src/docs/truffle/getting-started/running-migrations.md
@@ -254,3 +254,18 @@ deployer.then(function() {
   return b.setA(a.address);
 });
 ```
+
+### Migrations with async/await
+
+You can also migrate your contracts using `async/await`:
+
+Example:
+
+```javascript
+module.exports = async function(deployer) {
+  // deploy a contract
+  await deployer.deploy(MyContract);
+  //access information about your deployed contract instance
+  const MyDeployedContract = MyContract.deployed();
+}
+```

--- a/src/docs/truffle/getting-started/running-migrations.md
+++ b/src/docs/truffle/getting-started/running-migrations.md
@@ -266,6 +266,6 @@ module.exports = async function(deployer) {
   // deploy a contract
   await deployer.deploy(MyContract);
   //access information about your deployed contract instance
-  const MyDeployedContract = MyContract.deployed();
+  const instance = await MyContract.deployed();
 }
 ```


### PR DESCRIPTION
Adds a section to the Truffle migration documentation to explicitly state that migrations can be done using `async/await` syntax. 