### PR TITLE
Update guides href links

### DIFF
--- a/partials/docs-sidebar.hbs
+++ b/partials/docs-sidebar.hbs
@@ -59,11 +59,11 @@
       {{/each}}
       <h3>Guides</h3>
       <ul>
-        <a href="http://localhost:9000/guides/debugging-a-smart-contract"><li>Debugging a smart contract</li></a>
-        <a href="http://localhost:9000/guides/debugger-variable-inspection"><li>Variable Inspection: Going Deeper with the Truffle Solidity Debugger</li></a>
-        <a href="http://localhost:9000/guides/using-infura-custom-provider"><li>Using Infura (or a custom provider)</li></a>
-        <a href="http://localhost:9000/guides/deploying-to-the-live-network"><li>Deploying to the Live Network</li></a>
-        <a href="http://localhost:9000/guides/creating-a-cli-with-truffle-3"><li>Creating an Ethereum-enabled command line tool with Truffle 3.0</li></a>
+        <a href="/guides/debugging-a-smart-contract"><li>Debugging a smart contract</li></a>
+        <a href="/guides/debugger-variable-inspection"><li>Variable Inspection: Going Deeper with the Truffle Solidity Debugger</li></a>
+        <a href="/guides/using-infura-custom-provider"><li>Using Infura (or a custom provider)</li></a>
+        <a href="/guides/deploying-to-the-live-network"><li>Deploying to the Live Network</li></a>
+        <a href="/guides/creating-a-cli-with-truffle-3"><li>Creating an Ethereum-enabled command line tool with Truffle 3.0</li></a>
       </ul>
     </div>
 
@@ -86,8 +86,8 @@
       {{/each}}
       <h3>Guides</h3>
       <ul>
-        <a href="http://localhost:9000/guides/debugging-a-smart-contract"><li>Debugging a smart contract</li></a>
-        <a href="http://localhost:9000/guides/debugger-variable-inspection"><li>Variable Inspection: Going Deeper with the Truffle Solidity Debugger</li></a>
+        <a href="/guides/debugging-a-smart-contract"><li>Debugging a smart contract</li></a>
+        <a href="/guides/debugger-variable-inspection"><li>Variable Inspection: Going Deeper with the Truffle Solidity Debugger</li></a>
       </ul>
     </div>
 
@@ -110,8 +110,8 @@
       {{/each}}
       <h3>Guides</h3>
       <ul>
-        <a href="http://localhost:9000/guides/drizzle-and-contract-events"><li>Drizzle and Contract Events</li></a>
-        <a href="http://localhost:9000/guides/getting-started-with-drizzle-and-react"><li>Getting Started with Drizzle and React</li></a>
+        <a href="/guides/drizzle-and-contract-events"><li>Drizzle and Contract Events</li></a>
+        <a href="/guides/getting-started-with-drizzle-and-react"><li>Getting Started with Drizzle and React</li></a>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Changes proposed -
* Fix broken links at [Truffle Docs (sidebar)](https://www.trufflesuite.com/docs/truffle/overview) by removing `http://localhost:9000`
* Probably will resolve issue #959