### PR TITLE
Swap in Truffle precompiler for lib that was unpublished

### DIFF
--- a/metalsmith.js
+++ b/metalsmith.js
@@ -2,7 +2,7 @@ const Metalsmith = require('metalsmith');
 
 // Plugins
 const markdown = require('metalsmith-markdown');
-const markdownPrecompiler = require('metalsmith-markdown-precompiler');
+const markdownPrecompiler = require('@trufflesuite/metalsmith-markdown-precompiler');
 const sass = require('metalsmith-sass');
 const layouts = require('metalsmith-layouts');
 const discoverHelpers = require('metalsmith-discover-helpers');

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,14 @@
       "dev": true,
       "optional": true
     },
+    "@trufflesuite/metalsmith-markdown-precompiler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/metalsmith-markdown-precompiler/-/metalsmith-markdown-precompiler-1.0.1.tgz",
+      "integrity": "sha512-QuX1WuyFQxPOMTYu2XPOKCKbutizu1zDoVjLF0AuFZ846NU7ZC/WFwVU7XQefEkOdRhiYpcLDvq9xGU5UV7cBA==",
+      "requires": {
+        "handlebars": "^4.0.5"
+      }
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -5598,15 +5606,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
-      }
-    },
-    "metalsmith-markdown-precompiler": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-markdown-precompiler/-/metalsmith-markdown-precompiler-1.0.0.tgz",
-      "integrity": "sha1-3hxh1p6uVROuhXRyPyJgTCD5llY=",
-      "dev": true,
-      "requires": {
-        "handlebars": "^4.0.5"
       }
     },
     "metalsmith-paths": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "metalsmith-json-to-files": "^2.0.0",
     "metalsmith-layouts": "^2.1.0",
     "metalsmith-markdown": "^1.3.0",
-    "metalsmith-markdown-precompiler": "^1.0.0",
     "metalsmith-paths": "^3.0.1",
     "metalsmith-redirect": "^3.0.2",
     "metalsmith-sass": "^1.5.1",
@@ -37,6 +36,7 @@
     "recursive-uglifyjs": "^0.2.0"
   },
   "dependencies": {
+    "@trufflesuite/metalsmith-markdown-precompiler": "^1.0.1",
     "handlebars-helpers": "^0.10.0",
     "metalsmith-debug": "^1.2.0",
     "metalsmith-env": "^2.1.2"

--- a/partials/partial.html
+++ b/partials/partial.html
@@ -1,3 +1,3 @@
 <!--
-  DO NOT GET RID OF ME I AM WORKAROUND FOR `metalsmith-markdown-precompiler`.
+  DO NOT GET RID OF ME I AM WORKAROUND FOR `@trufflesuite/metalsmith-markdown-precompiler`.
 -->

--- a/src/docs/truffle/reference/configuration.md
+++ b/src/docs/truffle/reference/configuration.md
@@ -109,7 +109,7 @@ For each network, you can specify `host` / `port`, `url`, or `provider`, but not
 
 #### Providers
 
-The following network list consists of a local test network and an Infura-hosted Ropsten network, both provided by HDWalletProvider. Make sure you wrap `truffle-hdwallet` providers in a function closure as shown below to ensure that only one network is ever connected at a time.
+The following network list consists of a local test network and an Infura-hosted Ropsten network, both provided by HDWalletProvider. Make sure you wrap `@truffle/hdwallet-provider` instances in a function closure as shown below to ensure that only one network is ever connected at a time.
 
 ```javascript
 networks: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,13 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@trufflesuite/metalsmith-markdown-precompiler@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/metalsmith-markdown-precompiler/-/metalsmith-markdown-precompiler-1.0.1.tgz#bb35bed97f7d1bffc1de7bf249ab0809652af737"
+  integrity sha512-QuX1WuyFQxPOMTYu2XPOKCKbutizu1zDoVjLF0AuFZ846NU7ZC/WFwVU7XQefEkOdRhiYpcLDvq9xGU5UV7cBA==
+  dependencies:
+    handlebars "^4.0.5"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -2564,10 +2571,22 @@ handlebars-utils@^1.0.2, handlebars-utils@^1.0.4, handlebars-utils@^1.0.6:
     kind-of "^6.0.0"
     typeof-article "^0.1.1"
 
-handlebars@*, handlebars@^4.0.1, handlebars@^4.0.11, handlebars@^4.0.5:
+handlebars@*, handlebars@^4.0.1, handlebars@^4.0.11:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.0.5:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.0"
@@ -3980,13 +3999,6 @@ metalsmith-layouts@^2.1.0:
     is-utf8 "^0.2.1"
     jstransformer "^1.0.0"
     multimatch "^2.1.0"
-
-metalsmith-markdown-precompiler@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/metalsmith-markdown-precompiler/-/metalsmith-markdown-precompiler-1.0.0.tgz#de1c61d69eae5513ae8574723f22604c20f99656"
-  integrity sha1-3hxh1p6uVROuhXRyPyJgTCD5llY=
-  dependencies:
-    handlebars "^4.0.5"
 
 metalsmith-markdown@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
metalsmith-markdown-precompiler was unpublished by its author. Truffle published its own version of this library (@trufflesuite/metalsmith-markdown-precompiler) and this PR swaps it in for the old one.