### PR TITLE
Update tutorials links

### DIFF
--- a/src/docs/drizzle/reference/drizzle-actions.md
+++ b/src/docs/drizzle/reference/drizzle-actions.md
@@ -4,7 +4,7 @@ layout: docs.hbs
 ---
 # Drizzle Actions
 
-Drizzle emits many different actions that we can hook into with Middlewares. For more information about writing middlewares for Drizzle, [see the Drizzle and Contract Events tutorial](/tutorials/drizzle-and-contract-events).
+Drizzle emits many different actions that we can hook into with Middlewares. For more information about writing middlewares for Drizzle, [see the Drizzle and Contract Events guide](/guides/drizzle-and-contract-events).
 
 The main categories of actions pertain to:
 * [Accounts](#accounts)

--- a/src/docs/teams/quickstart.md
+++ b/src/docs/teams/quickstart.md
@@ -51,7 +51,7 @@ Builds will start automatically once a new commit is pushed to any branch of a r
 
 ## Deploying contracts
 
-Please see our detailed tutorial, ["Learning to Deploy with Truffle Teams"](https://www.trufflesuite.com/tutorials/learn-how-to-deploy-with-truffle-teams).
+Please see our detailed guide, ["Learning to Deploy with Truffle Teams"](https://www.trufflesuite.com/guides/learn-how-to-deploy-with-truffle-teams).
 
 ## Continue learning
 

--- a/src/docs/truffle/distributed-ledger-support/working-with-quorum.md
+++ b/src/docs/truffle/distributed-ledger-support/working-with-quorum.md
@@ -5,9 +5,9 @@ layout: docs.hbs
 # Working With Quorum
 Truffle supports development with Quorum, a version of Ethereum that adds new features on top of what Ethereum already provides. Specifically, **Quorum adds the ability to create private blockchains between select participants, and more importantly adds transaction privacy on top of normal Ethereum transactions.**
 
-It is highly recommended you read our [tutorial on building a dapp on Quorum](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains) before using Truffle with Quorum.
+It is highly recommended you read our [guide on building a dapp on Quorum](/guides/building-dapps-for-quorum-private-enterprise-blockchains) before using Truffle with Quorum.
 
-Both the tutorial and this page have been updated for *at least* version `5.0.9` of `truffle`.
+Both the guide and this page have been updated for *at least* version `5.0.9` of `truffle`.
 
 ## Known Issues
 - Quorum support was completely broken in version `5.0.0`, and basic support was restored in `5.0.9`. Make sure you have at least `5.0.9`.
@@ -32,7 +32,7 @@ module.exports = {
 ## Using Privacy Features
 Privacy features have been restored in Truffle `5.0.14`. They are also available in `v4`.
 
-Please refer to the [Quorum tutorial](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains) to learn more about how to use the privacy features within Quorum. Here are some quick references for privacy within the tutorial:
-- [Deploying contracts privately](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#deploying-smart-contracts-on-quorum)
-- [Making transactions private](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#using-quorum-39-s-privacy-features-to-make-transactions-private)
-- [Interacting with your contracts privately](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains#interacting-with-contracts-privately).
+Please refer to the [Quorum guide](/guides/building-dapps-for-quorum-private-enterprise-blockchains) to learn more about how to use the privacy features within Quorum. Here are some quick references for privacy within the tutorial:
+- [Deploying contracts privately](/guides/building-dapps-for-quorum-private-enterprise-blockchains#deploying-smart-contracts-on-quorum)
+- [Making transactions private](/guides/building-dapps-for-quorum-private-enterprise-blockchains#using-quorum-39-s-privacy-features-to-make-transactions-private)
+- [Interacting with your contracts privately](/guides/building-dapps-for-quorum-private-enterprise-blockchains#interacting-with-contracts-privately).

--- a/src/docs/truffle/getting-started/truffle-with-metamask.md
+++ b/src/docs/truffle/getting-started/truffle-with-metamask.md
@@ -7,7 +7,7 @@ layout: docs.hbs
 Before you can interact with smart contracts in a browser, make sure they're compiled, deployed, and that you're interacting with them via `web3` in client-side JavaScript. We recommend using the [@truffle/contract](https://github.com/trufflesuite/truffle/tree/master/packages/contract) library, as it makes interacting with contracts easier and more robust.
 
 <p class="alert alert-info">
-<i class="far fa-info-circle"></i> <strong>Note</strong>: For more information on these topics, including using <code>@truffle/contract</code>, check out our <a href="/tutorials/pet-shop">Pet Shop</a> tutorial.
+<i class="far fa-info-circle"></i> <strong>Note</strong>: For more information on these topics, including using <code>@truffle/contract</code>, check out our <a href="/tutorial">Pet Shop</a> tutorial.
 </p>
 
 Once you've done the above, you're ready to use MetaMask.

--- a/src/docs/truffle/quickstart.md
+++ b/src/docs/truffle/quickstart.md
@@ -7,7 +7,7 @@ layout: docs.hbs
 This page will take you through the basics of creating a Truffle project and deploying a smart contract to a blockchain.
 
 <p class="alert alert-info">
-<i class="far fa-info-circle"></i> <strong>Note</strong>: Before you begin, make sure that you read our <a href="/tutorials/ethereum-overview">Ethereum Overview</a> page.
+<i class="far fa-info-circle"></i> <strong>Note</strong>: Before you begin, make sure that you read our <a href="/guides/ethereum-overview">Ethereum Overview</a> page.
 </p>
 
 ## Table of Contents
@@ -474,4 +474,4 @@ As of Truffle v5, the console supports async/await functions, enabling much simp
 
 ## Continue learning
 
-This quickstart showed you the basics of the Truffle project lifecycle, but there is much more to learn. Please continue on with the rest of our [documentation](/docs) and especially our [tutorials](/tutorials) to learn more.
+This quickstart showed you the basics of the Truffle project lifecycle, but there is much more to learn. Please continue on with the rest of our [documentation](/docs) and especially our [guides](/guides) or [tutorial](/tutorial) to learn more.

--- a/src/docs/truffle/testing/writing-tests-in-solidity.md
+++ b/src/docs/truffle/testing/writing-tests-in-solidity.md
@@ -136,7 +136,7 @@ Solidity tests come with a few advanced features to let you test specific use ca
 
 You can easily test if your contract should or shouldn't raise an exception (i.e., for `require()`/`assert()`/`revert()` statements; `throw` on previous versions of Solidity).
 
-This topic was first written about by guest writer Simon de la Rouviere in [his tutorial Testing for Throws in Truffle Solidity Tests](/tutorials/testing-for-throws-in-solidity-tests).  N.B. that the tutorial makes heavy use of exceptions via the deprecated keyword `throw`, replaced by `revert()`, `require()`, and `assert()` starting in Solidity v0.4.13.
+This topic was first written about by guest writer Simon de la Rouviere in [his guide Testing for Throws in Truffle Solidity Tests](/guides/testing-for-throws-in-solidity-tests).  N.B. that the guide makes heavy use of exceptions via the deprecated keyword `throw`, replaced by `revert()`, `require()`, and `assert()` starting in Solidity v0.4.13.
 
 Also, since Solidity v0.4.17, a function type member was added to enable you to access a function selector (e.g.: `this.f.selector`), and so, testing for throws with external calls has been made much easier:
 ```solidity


### PR DESCRIPTION
Fixes #988.  This PR updates `/tutorials` links to `/guides`, except in one case where it's updated to `/tutorial`.  Hopefully this should be everything?

Note that I did *not* update references to *images* under `/img/tutorials`, because that is in fact where such images currently live (I don't know if we want to change this).