### PR TITLE
Link updates for overview docs

### DIFF
--- a/src/guides/ethereum-overview.md
+++ b/src/guides/ethereum-overview.md
@@ -194,7 +194,7 @@ Private Ethereum networks allow parties to share data without making it publicly
 * Sharing of sensitive data, such as health care records
 * Scaling to handle higher read/write throughput, due to the smaller network size
 
-An example of a private enterprise blockchain is [Quorum](https://www.jpmorgan.com/country/US/EN/Quorum), originally written by J.P. Morgan. ([Read our blog post on using Truffle with Quorum.](/docs/truffle/distributed-ledger-support/working-with-quorum))
+An example of a private enterprise blockchain is [Quorum](https://www.jpmorgan.com/country/US/EN/Quorum), originally written by J.P. Morgan. ([Read our documentation on using Truffle with Quorum.](/docs/truffle/distributed-ledger-support/working-with-quorum))
 
 
 ## Decentralized applications (dapps)

--- a/src/guides/ethereum-overview.md
+++ b/src/guides/ethereum-overview.md
@@ -194,12 +194,12 @@ Private Ethereum networks allow parties to share data without making it publicly
 * Sharing of sensitive data, such as health care records
 * Scaling to handle higher read/write throughput, due to the smaller network size
 
-An example of a private enterprise blockchain is [Quorum](https://www.jpmorgan.com/country/US/EN/Quorum), originally written by J.P. Morgan. ([Read our blog post on using Truffle with Quorum.](/tutorials/building-dapps-for-quorum-private-enterprise-blockchains))
+An example of a private enterprise blockchain is [Quorum](https://www.jpmorgan.com/country/US/EN/Quorum), originally written by J.P. Morgan. ([Read our blog post on using Truffle with Quorum.](/docs/truffle/distributed-ledger-support/working-with-quorum))
 
 
 ## Decentralized applications (dapps)
 
-**Applications using smart contracts for their processing and/or datastorage are called "decentralized applications", or "dapps".** The user interfaces for these dapps consist of familiar languages such as HTML, CSS, and JavaScript. The application itself can be hosted on a traditional web server or on a decentralized file service such as [Swarm](http://swarm-gateways.net/bzz:/theswarm.eth/) or [IPFS](http://ipfs.io/).
+**Applications using smart contracts for their processing and/or datastorage are called "decentralized applications", or "dapps".** The user interfaces for these dapps consist of familiar languages such as HTML, CSS, and JavaScript. The application itself can be hosted on a traditional web server or on a decentralized file service such as [Swarm](https://swarm-gateways.net/) or [IPFS](http://ipfs.io/).
 
 Given the benefits of the Ethereum blockchain, a dapp could be a solution for many industries, including but not limited to:
 

--- a/src/guides/getting-started-with-drizzle-and-react.md
+++ b/src/guides/getting-started-with-drizzle-and-react.md
@@ -5,7 +5,7 @@ We're going to focus on the lower levels today, taking you through setting up a 
 This will be a very minimal tutorial focused on setting and getting a simple string stored in a contract. It's meant for those with a basic knowledge of Truffle, who have some knowledge of JavaScript and React.js, but who are new to using Drizzle.
 
 <p class="alert alert-info">
-<i class="far fa-info-circle"></i> <strong>Note</strong>: For Truffle basics, please read through the Truffle <a href="/tutorials/pet-shop">Pet Shop</a> tutorial before proceeding.
+<i class="far fa-info-circle"></i> <strong>Note</strong>: For Truffle basics, please read through the Truffle <a href="/tutorial">Pet Shop</a> tutorial before proceeding.
 </p>
 
 In this tutorial we will be covering:


### PR DESCRIPTION
Have been finding outdated href's to 404 pages while reading through docs. 

Not sure which Swarm client you are trying to link to : https://swarm-gateways.net/ says it is being deprecated. 
