### PR TITLE
Update links for pet shop tutorial

### DIFF
--- a/src/blog/an-easier-way-to-deploy-your-smart-contracts.md
+++ b/src/blog/an-easier-way-to-deploy-your-smart-contracts.md
@@ -122,7 +122,7 @@ To get started with Truffle Teams, you must first connect your GitHub repository
 
 ### Setup Your Migrations Scripts
 
-If you haven't built a Truffle project, you should really give it a try; the [Pet Shop Tutorial](/tutorials/pet-shop) is a great place to start as it gives a good survey of the different facets of Truffle, including the `migration` scripts. These scripts let you define the behavior of deploying your smart contracts using a language you're already familiar with. In the tutorial, you deploy a single contract, but it has the flexibility to do so much more (i.e. you can deploy one contract, get its address, and use that in the constructor when deploying another contract).
+If you haven't built a Truffle project, you should really give it a try; the [Pet Shop Tutorial](/tutorial) is a great place to start as it gives a good survey of the different facets of Truffle, including the `migration` scripts. These scripts let you define the behavior of deploying your smart contracts using a language you're already familiar with. In the tutorial, you deploy a single contract, but it has the flexibility to do so much more (i.e. you can deploy one contract, get its address, and use that in the constructor when deploying another contract).
 
 Setting up these scripts is part of the development lifecycle of creating a Truffle project, so I won't cover that here. But that's great! You should already be done with this step!!
 

--- a/src/blog/learn-ethereum-the-fun-way-with-our-pet-shop-tutorial.md
+++ b/src/blog/learn-ethereum-the-fun-way-with-our-pet-shop-tutorial.md
@@ -1,4 +1,4 @@
-Here at Truffle we want to make Ethereum development accessible to developers of all stripes. To that end, today we're releasing a new tutorial called [Pet Shop](/tutorials/pet-shop). It covers the entire local development process, start to finish. For added fun, we've tied the whole thing together within the narrative of creating a pet adoption dapp for a local pet shop owner.
+Here at Truffle we want to make Ethereum development accessible to developers of all stripes. To that end, today we're releasing a new tutorial called [Pet Shop](/tutorial). It covers the entire local development process, start to finish. For added fun, we've tied the whole thing together within the narrative of creating a pet adoption dapp for a local pet shop owner.
 
 Here's a preview of what's covered:
 
@@ -15,7 +15,7 @@ By then end of the tutorial you'll have a shiny new dapp with which you can rese
 
 In the future we'll be building on this tutorial with others such as deploying to live testnets and additional, more advanced functionality. We hope you enjoy and thank everyone for your support!
 
-Got stuck? The fastest way to get help is from our [community Gitter channel](https://github.com/ConsenSys/truffle), where hundreds of your fellow Trufflers congregate to answer your questions. 
+Got stuck? The fastest way to get help is from our [community Gitter channel](https://github.com/ConsenSys/truffle), where hundreds of your fellow Trufflers congregate to answer your questions.
 
 Love it? Send us your feedback on [Twitter](https://twitter.com/trufflesuite).
 

--- a/src/guides/robust-smart-contracts-with-openzeppelin.md
+++ b/src/guides/robust-smart-contracts-with-openzeppelin.md
@@ -11,7 +11,7 @@ We can use and extend these contracts to create more secure dapps in less time. 
 
 ## Requirements
 
-This tutorial expects you to have some knowledge of Truffle, Ethereum, and Solidity. If you haven't gone through our [Ethereum overview](/tutorials/ethereum-overview) and our [Pet Shop tutorial](/tutorials/pet-shop) yet, those would be great places to start.
+This tutorial expects you to have some knowledge of Truffle, Ethereum, and Solidity. If you haven't gone through our [Ethereum overview](/guides/ethereum-overview) and our [Pet Shop tutorial](/tutorial) yet, those would be great places to start.
 
 For even more information, please see the following links:
 
@@ -164,7 +164,7 @@ Using less than 15 lines of hand-coded Solidity, we've created our own Ethereum 
 
 ## Interacting with the new token
 
-For this portion of the tutorial, we recommend using [MetaMask](http://metamask.io), a browser extension for Chrome and Firefox. It will allow you to switch between accounts quickly, perfect for testing the ability to transfer our newly created tokens. Our [Pet Shop tutorial](/tutorials/pet-shop) has more information about [configuring MetaMask](/tutorials/pet-shop#interacting-with-the-dapp-in-a-browser).
+For this portion of the tutorial, we recommend using [MetaMask](http://metamask.io), a browser extension for Chrome and Firefox. It will allow you to switch between accounts quickly, perfect for testing the ability to transfer our newly created tokens. Our [Pet Shop tutorial](/tutorial) has more information about [configuring MetaMask](/tutorial#interacting-with-the-dapp-in-a-browser).
 
 You will want to enter the mnemonic displayed in Ganache into MetaMask, and make sure that MetaMask is listening to the Custom RPC `http://127.0.0.1:7545`.
 

--- a/src/guides/using-infura-custom-provider.md
+++ b/src/guides/using-infura-custom-provider.md
@@ -8,7 +8,7 @@ For security reasons, Infura does not manage your private keys, which means Infu
 
 However, Truffle can sign transactions through the use of its `HDWalletProvider`. This provider can handle the transaction signing as well as the connection to the Ethereum network. ([Read more about HDWalletProvider](https://github.com/trufflesuite/truffle/tree/develop/packages/hdwallet-provider).)
 
-This tutorial will show you how to use Infura to migrate an existing dapp to an Ethereum network supported by Infura. In this specific instance, we'll migrate to Ropsten. We'll assume that you already have a dapp to migrate. If you want a test dapp, feel free to use our [Pet Shop](/tutorials/pet-shop) tutorial dapp.
+This tutorial will show you how to use Infura to migrate an existing dapp to an Ethereum network supported by Infura. In this specific instance, we'll migrate to Ropsten. We'll assume that you already have a dapp to migrate. If you want a test dapp, feel free to use our [Pet Shop](/tutorial) tutorial dapp.
 
 ## Install HDWalletProvider
 


### PR DESCRIPTION
This PR fixes a bunch of links to the pet shop tutorial. It was changed a while ago from /tutorials/pet-shop to /tutorial.