### PR TITLE
remove `App.markAdopted()` inside `initContract`

### DIFF
--- a/src/guides/pet-shop.md
+++ b/src/guides/pet-shop.md
@@ -548,9 +548,6 @@ Now that we can interact with Ethereum via web3, we need to instantiate our smar
 
      // Set the provider for our contract
      App.contracts.Adoption.setProvider(App.web3Provider);
-
-     // Use our contract to retrieve and mark the adopted pets
-     return App.markAdopted();
    });
    ```
 


### PR DESCRIPTION
In `app.js`, calling `App.markAdopted()` inside `initContract` marks all the records as adopted when starting the server. We can safely remove this line
```
// Use our contract to retrieve and mark the adopted pets
return App.markAdopted();
```
from `initContract` since running  `truffle unbox pet-shop` generates below code for `src/js/app.js`
```
  :
  :
  initContract: function() {
    /*
     * Replace me...
     */

    return App.bindEvents();
  },

  bindEvents: function() {
    $(document).on('click', '.btn-adopt', App.handleAdopt);
  },
  :
  :
```