### PR TITLE
Add missing dot at the end of a sentence.

### DIFF
--- a/src/tutorial/index.md
+++ b/src/tutorial/index.md
@@ -421,7 +421,7 @@ Truffle is very flexible when it comes to smart contract testing, in that tests 
 
   ```
   We start the contract by importing : 
-  * `Adoption`: The smart contract we want to test
+  * `Adoption`: The smart contract we want to test.
   We begin our test by importing our `Adoption` contract using `artifacts.require`.
 
   **Note**: When writing this test, our callback function take the argument `accounts`. This provides us with the accounts available on the network when using this test.


### PR DESCRIPTION
While reading through the tutorial, I noticed a place where a dot was missing. In the way Markdown formats the copy, line 418 and 419 here ends up in one paragraph. I propose adding a dot at the end of line 418 to fix this.