### PR TITLE
Add the list subcommand to the config command

### DIFF
--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -55,14 +55,15 @@ Options:
 Displays and sets user-level configuration options.
 
 ```shell
-truffle config [--enable-analytics|--disable-analytics] [[<get|set> <key>] [<value-for-set>]]
+truffle config [--enable-analytics|--disable-analytics] [[<get|set> <key>] [<list>] [<value-for-set>]]
 ```
 
 Options:
 
-- `--enable-analytics|--disable-analytics`: Enable or disable analytics.
-- `get`: Get a Truffle configuration option value.
-- `set`: Set a Truffle configuration option value.
+* `--enable-analytics|--disable-analytics`: Enable or disable analytics.
+* `get`: Get a Truffle configuration option value.
+* `set`: Set a Truffle configuration option value.
+* `list`: List all Truffle configuration option values.
 
 ### console
 


### PR DESCRIPTION
Recently a `list` subcommand was added to Truffle in https://github.com/trufflesuite/truffle/pull/4443. This PR documents it. It also adds `build` and `node_modules` directories to the `.gitignore`.