### PR TITLE
Refactor Build steps

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,24 +13,63 @@ from jinja2 import Template
 def define_env(env):
     "Definition of the module"
 
-    # TODO move dupe config here as variables
-
-def on_pre_page_macros(env):
-    "Pre-page actions"
-
     # boxes page
     data_file_object = open('src/boxes/data.json')
-    boxes = json.load(data_file_object)
+    boxes  = json.load(data_file_object)
+
+    # dict: repoName -> box
+    dicBox = dict(zip(
+        [box['repoName'] for box in boxes], 
+        boxes
+    ))
 
     boxes_file_object = open('src/data/boxes.json')
     deets = json.load(boxes_file_object)
 
-    for box in boxes:
-        for key in deets.keys():
-            if key == box['repoName']: # TODO lowercase before check
-                box['deets'] = deets[key]
-    
-    env.conf['extra']['boxes'] = boxes
+    # merge boxes and deets
+    for key in deets.keys():
+        try:
+            dicBox[key]['deets'] = deets[key]
+        except KeyError:
+            print("%s is not a box!" % key)
+
+    # env.conf['extra']['boxes'] = boxes
+    env.conf['extra']['boxes'] = list(dicBox.values())
+
+    if os.environ.get("LOCAL_BUILD"):
+        env.conf['extra']['boxes'] = env.conf['extra']['boxes'][:6] 
+
+    site_dir = env.conf['docs_dir']
+    username = os.environ.get("TRUFFLESUITE_COM_GH_API_USERNAME")
+    key = os.environ.get("TRUFFLESUITE_COM_GH_API_KEY")
+    for box in env.conf['extra']['boxes']:
+        print(box['repoName'])
+
+        box_dir = os.path.join(site_dir, 'boxes', box['displayName'])
+        if os.path.exists(box_dir):
+            shutil.rmtree(box_dir)
+        os.makedirs(box_dir)
+        file_path = os.path.join(box_dir, 'index.md')
+
+        response = requests.get("https://api.github.com/repos/" + box['userOrg'] + "/" + box['repoName'] + "/readme", auth=HTTPBasicAuth(username, key))
+        json_response = response.json()
+
+        try:
+            markdown = base64.b64decode(json_response['content'])
+
+            with open('src/boxes/box.html.jinja2') as file_:
+                template = Template(file_.read())
+
+            outputText = template.render(box=box, readme=markdown.decode('utf-8'))
+
+            with open(file_path, 'w') as f:
+                f.write(outputText)
+
+        except Exception as ex:
+            print('error: ' + repr(ex))
+
+def on_pre_page_macros(env):
+    "Pre-page actions"
 
     # blog posts page
     blog_file_object = open('src/blog/data.json')
@@ -69,46 +108,3 @@ def on_pre_page_macros(env):
 def on_post_build(env):
     "Post-build actions"
 
-    # box individual pages
-    site_dir = env.conf['docs_dir']
-    file_object = open('src/boxes/data.json')
-    boxes = json.load(file_object)
-    
-    username = os.environ.get("TRUFFLESUITE_COM_GH_API_USERNAME")
-    key = os.environ.get("TRUFFLESUITE_COM_GH_API_KEY")
-
-    for box in boxes:
-
-        print(box['repoName'])
-
-        box_dir = os.path.join(site_dir, 'boxes', box['displayName'])
-        if os.path.exists(box_dir):
-            shutil.rmtree(box_dir)
-        os.makedirs(box_dir)
-        file_path = os.path.join(box_dir, 'index.md')
-
-        response = requests.get("https://api.github.com/repos/" + box['userOrg'] + "/" + box['repoName'] + "/readme", auth=HTTPBasicAuth(username, key))
-        json_response = response.json()
-
-        try:
-
-            markdown = base64.b64decode(json_response['content'])
-
-            with open('src/boxes/box.html.jinja2') as file_:
-                template = Template(file_.read())
-
-            outputText = template.render(box=box, readme=markdown.decode('utf-8'))
-
-            with open(file_path, 'w') as f:
-                f.write(outputText)
-
-        except Exception as ex:
-            print('error: ' + repr(ex))
-
-    # rebuild?
-    conf = env.conf
-  
-    if not conf['extra']['rebuild']:
-        conf['extra']['rebuild'] = True
-        mkdocs.commands.build.build(conf)
-    


### PR DESCRIPTION
- Consolidate building box meta to define_env so it is available in other
mkdocs lifecycles. This removes the need for on_post_build lifecycle
- add ability to limit the local build to 6 boxes to save on network
  lookups. Use as follows:
  ```
  LOCAL_BUILD=true mkdocs serve [-a 0.0.0.0:8000]
  ```
