### PR TITLE
Rename debugging guide name

### DIFF
--- a/src/docs/data.json
+++ b/src/docs/data.json
@@ -60,7 +60,7 @@
       "Truffle with MetaMask",
       "Package Management via EthPM",
       "Package Management via NPM",
-      "Debugging Your Contracts",
+      "Using the Truffle Debugger",
       "Using Truffle Develop and The Console",
       "Writing External Scripts",
       "Preserving Files and Content to Storage Platforms"
@@ -145,8 +145,7 @@
     }
   },
   "filecoin": {
-    "truffle": {
-    },
+    "truffle": {},
     "ganache": {
       "Getting Started": [
         "Get Started with the CLI",

--- a/src/docs/truffle/getting-started/using-the-truffle-debugger.md
+++ b/src/docs/truffle/getting-started/using-the-truffle-debugger.md
@@ -1,8 +1,8 @@
 ---
-title: Truffle | Debugging Your Contracts
+title: Truffle | Using the Truffle Debugger
 layout: docs.hbs
 ---
-# Debugging Your Contracts
+# Using the Truffle Debugger
 
 Truffle includes an integrated debugger so that you can debug transactions made against your contracts. This debugger looks and feels like existing command line debuggers available for traditional development environments.
 

--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -2,10 +2,10 @@
 title: "Truffle Commands"
 layout: "docs.hbs"
 ---
+
 # Truffle Commands
 
 This section will describe every command available in the Truffle application.
-
 
 ## Usage
 
@@ -17,9 +17,7 @@ truffle <command> [options]
 
 Passing no arguments is equivalent to `truffle help`, which will display a list of all commands and then exit.
 
-
 ## Available commands
-
 
 ### build
 
@@ -35,7 +33,6 @@ Requires the `build` key to be present in the configuration. See the [Building y
 <i class="far fa-exclamation-triangle"></i> <strong>Warning</strong>: The <code>build</code> command and this approach is being deprecated. Please use third-party build tools like webpack or grunt, or see our <a href="/boxes">Truffle Boxes</a> for an example.
 </p>
 
-
 ### compile
 
 Compile contract source files.
@@ -48,10 +45,10 @@ This will only compile contracts that have changed since the last compile, unles
 
 Options:
 
-* `--list <filter>`: List all recent stable releases from solc-bin. If filter is specified then it will display only that type of release or docker tags.  The filter parameter must be one of the following: prereleases, releases, latestRelease or docker.
-* `--all`: Compile all contracts instead of only the contracts changed since last compile.
-* `--network <name>`: Specify the network to use, saving artifacts specific to that network. Network name must exist in the configuration.
-* `--quiet`: Suppress all compilation output.
+- `--list <filter>`: List all recent stable releases from solc-bin. If filter is specified then it will display only that type of release or docker tags. The filter parameter must be one of the following: prereleases, releases, latestRelease or docker.
+- `--all`: Compile all contracts instead of only the contracts changed since last compile.
+- `--network <name>`: Specify the network to use, saving artifacts specific to that network. Network name must exist in the configuration.
+- `--quiet`: Suppress all compilation output.
 
 ### config
 
@@ -63,10 +60,9 @@ truffle config [--enable-analytics|--disable-analytics] [[<get|set> <key>] [<val
 
 Options:
 
-* `--enable-analytics|--disable-analytics`: Enable or disable analytics.
-* `get`: Get a Truffle configuration option value.
-* `set`: Set a Truffle configuration option value.
-
+- `--enable-analytics|--disable-analytics`: Enable or disable analytics.
+- `get`: Get a Truffle configuration option value.
+- `set`: Set a Truffle configuration option value.
 
 ### console
 
@@ -84,9 +80,8 @@ See the [Using the console](/docs/getting_started/console) section for more deta
 
 Options:
 
-* `--network <name>`: Specify the network to use. Network name must exist in the configuration.
-* `--verbose-rpc`: Log communication between Truffle and the Ethereum client.
-
+- `--network <name>`: Specify the network to use. Network name must exist in the configuration.
+- `--verbose-rpc`: Log communication between Truffle and the Ethereum client.
 
 ### create
 
@@ -98,11 +93,10 @@ truffle create <artifact_type> <ArtifactName>
 
 Options:
 
-* `<artifact_type>`: Create a new artifact where artifact_type is one of the following: contract, migration or test. The new artifact is created along with one of the following files: `contracts/ArtifactName.sol`, `migrations/####_artifact_name.js` or `tests/artifact_name.js`. (required)
-* `<ArtifactName>`: Name of new artifact. (required)
+- `<artifact_type>`: Create a new artifact, where `artifact_type` is one of the following: `contract`, `migration`, `test`, or `all`. The new artifact is created along with one of the following files: `contracts/ArtifactName.sol`, `migrations/####_artifact_name.js` or `tests/artifact_name.js`. Using `truffle create all` will create all three. (required)
+- `<ArtifactName>`: Name of new artifact. (required)
 
 Camel case names of artifacts will be converted to underscore-separated file names for the migrations and tests. Number prefixes for migrations are automatically generated.
-
 
 ### debug
 
@@ -112,23 +106,20 @@ Interactively debug any transaction on the blockchain.
 truffle debug [<transaction_hash>] [--network <network>] [--fetch-external] [--compile-tests|--compile-all|--compile-none]
 ```
 
-Will start an interactive debugging session on a particular transaction. Allows you to step through each action and replay. See the [Debugging your contracts](/docs/getting_started/debugging) section for more details.
-
+Will start an interactive debugging session on a particular transaction. Allows you to step through each action and replay. See [Using the truffle debugger](/docs/getting_started/using-the-truffle-debugger) for more details.
 
 Options:
 
-* `<transaction_hash>`: Transaction ID to use for debugging.  You can omit this to simply start the debugger and then load a transaction later.
-* `--network`: The network to connect to.
-* `--fetch-external`: Allows the debugger to download source from source verification services to debug transactions involving external contracts.  When used, a transaction hash is required.  May be abbreviated `-x`.
-* `--compile-tests`: Allows the debugger to compile [Solidity test contracts](../testing/writing-tests-in-solidity).  Implies `--compile-all`.
-* `--compile-all`: Forces the debugger to recompile all contracts, even when it would otherwise judge doing so unnecessary.  Compilation results are not saved.
-* `--compile-none`: Forces the debugger not to recompile contracts, even when it would otherwise judge it necessary.  This option is dangerous and may cause errors.  Please only use this if you are sure a recompilation is not necessary.
-
+- `<transaction_hash>`: Transaction ID to use for debugging. You can omit this to simply start the debugger and then load a transaction later.
+- `--network`: The network to connect to.
+- `--fetch-external`: Allows the debugger to download source from source verification services to debug transactions involving external contracts. When used, a transaction hash is required. May be abbreviated `-x`.
+- `--compile-tests`: Allows the debugger to compile [Solidity test contracts](../testing/writing-tests-in-solidity). Implies `--compile-all`.
+- `--compile-all`: Forces the debugger to recompile all contracts, even when it would otherwise judge doing so unnecessary. Compilation results are not saved.
+- `--compile-none`: Forces the debugger not to recompile contracts, even when it would otherwise judge it necessary. This option is dangerous and may cause errors. Please only use this if you are sure a recompilation is not necessary.
 
 ### deploy
 
 Alias for `migrate`. See [migrate](/docs/truffle/reference/truffle-commands#migrate) for details.
-
 
 ### develop
 
@@ -144,13 +135,11 @@ If you want an interactive console but want to use an existing blockchain, use `
 
 See the [Using the console](/docs/getting_started/console) section for more details.
 
-
 Option:
 
-* `--log`: Start/Connect to a Truffle develop session and log all RPC activity.
-See the [Log RPC Activity](docs/getting_started/console#log-rpc-activity)
-docs for more information about using this option.
-
+- `--log`: Start/Connect to a Truffle develop session and log all RPC activity.
+  See the [Log RPC Activity](docs/getting_started/console#log-rpc-activity)
+  docs for more information about using this option.
 
 ### exec
 
@@ -166,10 +155,9 @@ See the [Writing external scripts](/docs/getting_started/scripts) section for mo
 
 Options:
 
-* `<script.js>`: JavaScript file to be executed. Can include path information if the script does not exist in the current directory. (required)
-* `--network <name>`: Specify the network to use, using artifacts specific to that network. Network name must exist in the configuration.
-* `--compile`: Compile contracts before executing the script.
-
+- `<script.js>`: JavaScript file to be executed. Can include path information if the script does not exist in the current directory. (required)
+- `--network <name>`: Specify the network to use, using artifacts specific to that network. Network name must exist in the configuration.
+- `--compile`: Compile contracts before executing the script.
 
 ### help
 
@@ -181,8 +169,7 @@ truffle help [<command>]
 
 Option:
 
-* `<command>`: Display usage information about the specified command.
-
+- `<command>`: Display usage information about the specified command.
 
 ### init
 
@@ -200,8 +187,7 @@ Creates a new and empty Truffle project within the current working directory.
 
 Option:
 
-* `--force`: Initialize project regardless of the current working directory's state. Be careful, this could overwrite existing files that have name conflicts.
-
+- `--force`: Initialize project regardless of the current working directory's state. Be careful, this could overwrite existing files that have name conflicts.
 
 ### install
 
@@ -213,11 +199,10 @@ truffle install <package_name>[@<version>]
 
 Options:
 
-* `<package_name>`: Name of the package as listed in the Ethereum Package Registry. (required)
-* `@<version>`: When specified, will install a specific version of the package, otherwise will install the latest version.
+- `<package_name>`: Name of the package as listed in the Ethereum Package Registry. (required)
+- `@<version>`: When specified, will install a specific version of the package, otherwise will install the latest version.
 
 See the [Package Management with EthPM](/docs/getting_started/packages-ethpm) section for more details.
-
 
 ### migrate
 
@@ -231,17 +216,16 @@ Unless specified, this will run from the last completed migration. See the [Migr
 
 Options:
 
-* `--reset`: Run all migrations from the beginning, instead of running from the last completed migration.
-* `--f <number>`: Run contracts from a specific migration. The number refers to the prefix of the migration file.
-* `--to <number>`: Run contracts to a specific migration. The number refers to the prefix of the migration file.
-* `--network <name>`: Specify the network to use, saving artifacts specific to that network. Network name must exist in the configuration.
-* `--compile-all`: Compile all contracts instead of intelligently choosing which contracts need to be compiled.
-* `--verbose-rpc`: Log communication between Truffle and the Ethereum client.
-* `--dry-run`: Fork the network specified and only perform a test migration.
-* `--skip-dry-run`: Skip the test migration performed before the real migration.
-* `--interactive`: Prompt to confirm that the user wants to proceed after the dry run.
-* `--describe-json`: Prints additional status messages.
-
+- `--reset`: Run all migrations from the beginning, instead of running from the last completed migration.
+- `--f <number>`: Run contracts from a specific migration. The number refers to the prefix of the migration file.
+- `--to <number>`: Run contracts to a specific migration. The number refers to the prefix of the migration file.
+- `--network <name>`: Specify the network to use, saving artifacts specific to that network. Network name must exist in the configuration.
+- `--compile-all`: Compile all contracts instead of intelligently choosing which contracts need to be compiled.
+- `--verbose-rpc`: Log communication between Truffle and the Ethereum client.
+- `--dry-run`: Fork the network specified and only perform a test migration.
+- `--skip-dry-run`: Skip the test migration performed before the real migration.
+- `--interactive`: Prompt to confirm that the user wants to proceed after the dry run.
+- `--describe-json`: Prints additional status messages.
 
 ### networks
 
@@ -255,7 +239,7 @@ Use this command before publishing your package to see if there are any extraneo
 
 Option:
 
-* `--clean`: Remove all network artifacts that aren't associated with a named network.
+- `--clean`: Remove all network artifacts that aren't associated with a named network.
 
 ### obtain
 
@@ -267,8 +251,7 @@ truffle obtain [--solc <version>]
 
 Option:
 
-* `--solc`: Download and cache a version of the solc compiler. (required)
-
+- `--solc`: Download and cache a version of the solc compiler. (required)
 
 ### opcode
 
@@ -280,8 +263,7 @@ truffle opcode <contract_name>
 
 Option:
 
-* `<contract_name>`: Name of the contract to print opcodes for. Must be a contract name, not a file name. (required)
-
+- `<contract_name>`: Name of the contract to print opcodes for. Must be a contract name, not a file name. (required)
 
 ### preserve
 
@@ -293,14 +275,13 @@ truffle preserve <path> --<recipe> [--environment <name>]
 
 Options:
 
-* `--ipfs`: Preserve files to IPFS
-* `--filecoin`: Preserve files to Filecoin
-* `--buckets`: Preserve files to Textile Buckets
-* `--<recipe>`: Preserve files using an installed plugin with the specified recipe tag
-* `--environment <name>`: Specify the environment to use (defined in `truffle-config.js`) (default: "development")
+- `--ipfs`: Preserve files to IPFS
+- `--filecoin`: Preserve files to Filecoin
+- `--buckets`: Preserve files to Textile Buckets
+- `--<recipe>`: Preserve files using an installed plugin with the specified recipe tag
+- `--environment <name>`: Specify the environment to use (defined in `truffle-config.js`) (default: "development")
 
 Custom options for these "preserve recipes" can be provided through [environments](/docs/truffle/reference/configuration#environments). Additional preserve recipes can be installed through NPM and [configured as Truffle plugins](/docs/truffle/reference/configuration#plugins). More information about usage, configuration and installation of preserve recipes can be found on the [dedicated documentation page](/docs/truffle/getting-started/preserving-files-and-content-to-storage-platforms).
-
 
 ### publish
 
@@ -327,11 +308,10 @@ truffle run <command>
 
 Option:
 
-* `<command>`: Name of a command defined by an installed plugin. (required)
+- `<command>`: Name of a command defined by an installed plugin. (required)
 
 Install plugins as NPM package dependencies and [configure Truffle](/docs/truffle/reference/configuration#plugins)
 to recognize the plugin. For more information, see [Third-Party Plugin Commands](/docs/truffle/getting-started/writing-external-scripts#third-party-plugin-commands).
-
 
 ### test
 
@@ -345,18 +325,17 @@ Runs some or all tests within the `test/` directory as specified. See the sectio
 
 Options:
 
-* `<test_file>`: Name of the test file to be run. Can include path information if the file does not exist in the current directory.
-* `--compile-all`: Compile all contracts instead of intelligently choosing which contracts need to be compiled.
-* `--compile-all-debug`: Like `--compile-all`, but compiles contracts in debug mode for extra information.  Has no effect on Solidity <0.6.3.
-* `--network <name>`: Specify the network to use, using artifacts specific to that network. Network name must exist in the configuration.
-* `--verbose-rpc`: Log communication between Truffle and the Ethereum client.
-* `--show-events`: Log all contract events.
-* `--debug`: Provides global `debug()` function for in-test debugging. Usable with Javascript tests only; implies `--compile-all`.
-* `--debug-global <identifier>`: Allows one to rename the `debug()` function to something else.
-* `--bail`: Bail after the first test failure.  May be abbreviated `-b`.
-* `--stacktrace`: Allows for mixed Javascript-and-Solidity stacktraces when a Truffle Contract transaction or deployment reverts.  Does not apply to calls or gas estimates.  Implies `--compile-all`.  May be abbreviated `-t`.  Warning: This option is still somewhat experimental.
-* `--stacktrace-extra`: Shortcut for `--stacktrace --compile-all-debug`.
-
+- `<test_file>`: Name of the test file to be run. Can include path information if the file does not exist in the current directory.
+- `--compile-all`: Compile all contracts instead of intelligently choosing which contracts need to be compiled.
+- `--compile-all-debug`: Like `--compile-all`, but compiles contracts in debug mode for extra information. Has no effect on Solidity <0.6.3.
+- `--network <name>`: Specify the network to use, using artifacts specific to that network. Network name must exist in the configuration.
+- `--verbose-rpc`: Log communication between Truffle and the Ethereum client.
+- `--show-events`: Log all contract events.
+- `--debug`: Provides global `debug()` function for in-test debugging. Usable with Javascript tests only; implies `--compile-all`.
+- `--debug-global <identifier>`: Allows one to rename the `debug()` function to something else.
+- `--bail`: Bail after the first test failure. May be abbreviated `-b`.
+- `--stacktrace`: Allows for mixed Javascript-and-Solidity stacktraces when a Truffle Contract transaction or deployment reverts. Does not apply to calls or gas estimates. Implies `--compile-all`. May be abbreviated `-t`. Warning: This option is still somewhat experimental.
+- `--stacktrace-extra`: Shortcut for `--stacktrace --compile-all-debug`.
 
 ### unbox
 
@@ -371,20 +350,21 @@ defaults to the current working directory if this argument is not provided.
 
 See the [list of available Truffle boxes](/boxes).
 
-You can also design and create your own boxes!  See the section on [Truffle boxes](docs/truffle/advanced/creating-a-truffle-box) for more information.
+You can also design and create your own boxes! See the section on [Truffle boxes](docs/truffle/advanced/creating-a-truffle-box) for more information.
 
 Options:
 
-* `<box_name>`: Name of the Truffle Box. (required)
-* `--force`: Unbox project in the current directory regardless of its state. Be careful, this will potentially overwrite files that exist in the directory.
+- `<box_name>`: Name of the Truffle Box. (required)
+- `--force`: Unbox project in the current directory regardless of its state. Be careful, this will potentially overwrite files that exist in the directory.
 
 **Note**: box_name can be one of several formats:
-  1. \<truffleBoxName\> - like `metacoin` (see the official Truffle boxes [here](https://www.trufflesuite.com/boxes))
-  2. \<gitOrgName/repoName\> - like `truffle-box/bare-box` (your repo will have to
-    have the proper structure - see our page on [creating a Truffle
-    Box](docs/truffle/advanced/creating-a-truffle-box))
-  3. \<urlToGitRepo\> - like `https://github.com/truffle-box/bare-box`
-  4. \<sshUrlToGitRepo\> - like `git@github.com:truffle-box/bare-box`
+
+1. \<truffleBoxName\> - like `metacoin` (see the official Truffle boxes [here](https://www.trufflesuite.com/boxes))
+2. \<gitOrgName/repoName\> - like `truffle-box/bare-box` (your repo will have to
+   have the proper structure - see our page on [creating a Truffle
+   Box](docs/truffle/advanced/creating-a-truffle-box))
+3. \<urlToGitRepo\> - like `https://github.com/truffle-box/bare-box`
+4. \<sshUrlToGitRepo\> - like `git@github.com:truffle-box/bare-box`
 
 Also note that you can add a `#` followed by a branch name to the end of all
 of the above formats to unbox from a specific branch - for example, you could

--- a/src/guides/data.json
+++ b/src/guides/data.json
@@ -41,8 +41,8 @@
     "published": true,
     "products": ["truffle", "ganache"]
   },
-  "debugging-a-smart-contract": {
-    "title": "Debugging a smart contract",
+  "debugging-an-example-smart-contract": {
+    "title": "Debugging an example smart contract",
     "date": "2017-10-23",
     "author": "Mike Pumphrey",
     "published": true,

--- a/src/guides/debugging-an-example-smart-contract/index.md
+++ b/src/guides/debugging-an-example-smart-contract/index.md
@@ -1,5 +1,5 @@
 ---
-title: Debugging a smart contract
+title: Debugging an example smart contract
 hide:
   - navigation
 ---
@@ -21,8 +21,6 @@ If our contracts are not coded correctly, our transactions may fail, which can r
 **Luckily, Truffle (as of version 4) has a built in debugger for stepping through your code.** So when something goes wrong, you can find out exactly what it was, and fix it promptly.
 
 In this tutorial, we will migrate a basic contract to a test blockchain, introduce some errors into it, and solve each one through the use of the built-in Truffle debugger.
-
-
 
 ## A basic smart contract
 
@@ -46,8 +44,8 @@ contract SimpleStorage {
 
 This contract does two things:
 
-* Allows you to set a variable (`myVariable`) to a particular integer value
-* Allows you to query that variable to get the selected value
+- Allows you to set a variable (`myVariable`) to a particular integer value
+- Allows you to query that variable to get the selected value
 
 This isn't a very interesting contract, but that's not the point here. We want to see what happens when things go wrong.
 
@@ -95,7 +93,7 @@ First, let's set up our environment.
    ```javascript
    var SimpleStorage = artifacts.require("SimpleStorage");
 
-   module.exports = function(deployer) {
+   module.exports = function (deployer) {
      deployer.deploy(SimpleStorage);
    };
    ```
@@ -154,13 +152,19 @@ We next want to interact with the smart contract to see how it works when workin
 1. In the console where `truffle develop` is running, run the following command:
 
    ```javascript
-   SimpleStorage.deployed().then(function(instance){return instance.get.call();}).then(function(value){return value.toNumber()});
+   SimpleStorage.deployed()
+     .then(function (instance) {
+       return instance.get.call();
+     })
+     .then(function (value) {
+       return value.toNumber();
+     });
    ```
 
    This command looks at the SimpleStorage contract, and then calls the `get()` function as defined inside it. It then returns the output, which is usually rendered as a string, and converts it to a number:
 
    ```javascript
-   0
+   0;
    ```
 
    This shows us that our variable, `myVariable`, is set to `0`, even though we haven't set this variable to any value (yet). This is because **variables with integer types are automatically populated with the value of zero in Solidity**, unlike other languages where it might be `NULL` or `undefined`.
@@ -168,10 +172,12 @@ We next want to interact with the smart contract to see how it works when workin
 1. Now let's run a transaction on our contract. We'll do this by running the `set()` function, where we can set our variable value to some other integer. Run the following command:
 
    ```javascript
-   SimpleStorage.deployed().then(function(instance){return instance.set(4);});
+   SimpleStorage.deployed().then(function (instance) {
+     return instance.set(4);
+   });
    ```
 
-   This sets the variable to `4`. The output shows some information about the transaction, including the transaction ID (hash), transaction receipt,  and any event logs that were triggered during the course of the transaction:
+   This sets the variable to `4`. The output shows some information about the transaction, including the transaction ID (hash), transaction receipt, and any event logs that were triggered during the course of the transaction:
 
    ```javascript
     { tx: '0x7f799ad56584199db36bd617b77cc1d825ff18714e80da9d2d5a0a9fff5b4d42',
@@ -196,25 +202,30 @@ We next want to interact with the smart contract to see how it works when workin
 1. To verify that the variable has changed values, run the `get()` function again:
 
    ```javascript
-   SimpleStorage.deployed().then(function(instance){return instance.get.call();}).then(function(value){return value.toNumber()});
+   SimpleStorage.deployed()
+     .then(function (instance) {
+       return instance.get.call();
+     })
+     .then(function (value) {
+       return value.toNumber();
+     });
    ```
 
    The output should look like this:
 
    ```javascript
-   4
+   4;
    ```
 
 ## Debugging errors
 
-The above shows how the contract *should* work. Now, we will introduce some small errors to the contract and redeploy it. We will see how the issues present itself, and also **use Truffle's built-in debug feature to fix the issues**.
+The above shows how the contract _should_ work. Now, we will introduce some small errors to the contract and redeploy it. We will see how the issues present itself, and also **use Truffle's built-in debug feature to fix the issues**.
 
 We will look at the following issues:
 
-* An infinite loop
-* Invalid error check
-* No error, but a function isn't operating as desired
-
+- An infinite loop
+- Invalid error check
+- No error, but a function isn't operating as desired
 
 ### Issue #1: An infinite loop
 
@@ -265,7 +276,9 @@ The Truffle Develop console has the ability to migrate updated contracts without
 1. Now we are ready to run that transaction. Run the `set()` command from above.
 
    ```javascript
-   SimpleStorage.deployed().then(function(instance){return instance.set(4);});
+   SimpleStorage.deployed().then(function (instance) {
+     return instance.set(4);
+   });
    ```
 
    An error will display:
@@ -301,7 +314,6 @@ Truffle contains a built-in debugger. The command to launch this is `debug <Tran
    <p class="alert alert-info">
    <strong>Note</strong>: Again, your transaction ID will be different from what is listed here.
    </p>
-
 
    You will see the following output:
 
@@ -414,7 +426,6 @@ Truffle contains a built-in debugger. The command to launch this is `debug <Tran
 
 1. Type `q` to exit the debugger.
 
-
 ### Issue #2: An invalid error check
 
 Smart contracts can use statements like `assert()` to ensure that certain conditions are met. These can conflict with the state of the contract in ways that are irreconcilable.
@@ -449,7 +460,9 @@ Just as before, we'll reset the contract on the blockchain.
 1. Now we are ready to test the new transaction. Run the same command as above:
 
    ```javascript
-   SimpleStorage.deployed().then(function(instance){return instance.set(4);});
+   SimpleStorage.deployed().then(function (instance) {
+     return instance.set(4);
+   });
    ```
 
    You will see an error:
@@ -473,7 +486,6 @@ Just as before, we'll reset the contract on the blockchain.
    <p class="alert alert-info">
    <strong>Note</strong>: Again, your transaction ID will be different from what is listed here.
    </p>
-
 
    Now we are back in the debugger:
 
@@ -509,7 +521,6 @@ Just as before, we'll reset the contract on the blockchain.
    ```
 
    **It is this last event that is triggering the error.** You can see that it is the `assert()` that is to blame.
-
 
 ### Issue #3: A function isn't operating as desired
 
@@ -559,7 +570,9 @@ Just as before, we'll reset the contract on the blockchain.
 1. Now we are ready to test the new transaction. Run the same command as above:
 
    ```javascript
-   SimpleStorage.deployed().then(function(instance){return instance.set(4);});
+   SimpleStorage.deployed().then(function (instance) {
+     return instance.set(4);
+   });
    ```
 
    **Note that there is no error here.** The response is given as a transaction ID with details:
@@ -626,7 +639,6 @@ Just as before, we'll reset the contract on the blockchain.
    ```
 
    **The problem is revealed.** The conditional is leading to the wrong event.
-
 
 ## Conclusion
 

--- a/src/guides/debugging-an-example-smart-contract/index.md
+++ b/src/guides/debugging-an-example-smart-contract/index.md
@@ -163,8 +163,8 @@ We next want to interact with the smart contract to see how it works when workin
 
    This command looks at the SimpleStorage contract, and then calls the `get()` function as defined inside it. It then returns the output, which is usually rendered as a string, and converts it to a number:
 
-   ```javascript
-   0;
+   ```shell
+   0
    ```
 
    This shows us that our variable, `myVariable`, is set to `0`, even though we haven't set this variable to any value (yet). This is because **variables with integer types are automatically populated with the value of zero in Solidity**, unlike other languages where it might be `NULL` or `undefined`.
@@ -213,8 +213,8 @@ We next want to interact with the smart contract to see how it works when workin
 
    The output should look like this:
 
-   ```javascript
-   4;
+   ```shell
+   4
    ```
 
 ## Debugging errors


### PR DESCRIPTION
Differentiate between the truffle debugger documentation from the example contract debugging guide.