### PR TITLE
fixing nested slug 404 issue

### DIFF
--- a/src/404.md
+++ b/src/404.md
@@ -1,4 +1,0 @@
----
-template: 404.html
-title: Truffle Suite
----

--- a/src/ipfs-404.md
+++ b/src/ipfs-404.md
@@ -1,4 +1,0 @@
----
-template: ipfs-404.html
-title: Truffle Suite
----


### PR DESCRIPTION
Rationale behind fix for reference: "_i think it's because that causes it to generate a `404.html` in the root (with the dynamically generated css files being referenced relatively `assets/css/dynamic.css` vs absolutely `/assets/css/dynamic.css`). as such it's fine for a single slug broken link...e.g. `trufflesuite.com/doh` but not for `trufflesuite.com/doh/doh`. removing the file (really it's just `404.md`) causes mkdocs to handle it differently (e.g. correctly)_"