### PR TITLE
Fixing broken Ganache download button

### DIFF
--- a/custom_theme/ganache.html
+++ b/custom_theme/ganache.html
@@ -206,7 +206,7 @@
     </div>
 </div>
 
-<script src="/assets/js/os-detector.js"></script>
+<script src="/assets/js/os-detector.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 
 {% endblock %}


### PR DESCRIPTION
Fixing https://github.com/trufflesuite/trufflesuite.com/issues/1138 due to the OS detection script was being incorrectly referenced now that all the `.js` / `.css` assets are now being minified per https://github.com/trufflesuite/trufflesuite.com/pull/1133.