### PR TITLE
Update messaging in announcement bar

### DIFF
--- a/custom_theme/main.html
+++ b/custom_theme/main.html
@@ -7,8 +7,8 @@
 
 <!-- Announcement bar -->
 {% block announce %}
-  <a href="https://bit.ly/3zPGqM1">
-    <strong>Ganache v7 beta is ready for you to install!</strong> Try out the new <em>zero-config mainnet forking</em>!
+  <a href="https://github.com/trufflesuite/ganache/releases/tag/ganache%407.0.0-rc.0" rel="nofollow">
+    <strong>Ganache v7 Release Candidate is ready for you to install!</strong> Try out the new <em>zero-config mainnet forking</em>!
     <!-- <span class="twemoji twitter">
       {% include ".icons/fontawesome/brands/github.svg" %}
     </span> -->


### PR DESCRIPTION
This updates the link to the correct one and add nofollow so we don't pass our PageRank to github.