### PR TITLE
fix: quickstart shell code block formatting

### DIFF
--- a/src/docs/truffle/quickstart.md
+++ b/src/docs/truffle/quickstart.md
@@ -101,7 +101,7 @@ Once this operation is completed, you'll now have a project structure with the f
 
    You will see the following output:
 
-    ```shell
+   ```shell
      TestMetacoin
        √ testInitialBalanceUsingDeployedContract (71ms)
        √ testInitialBalanceWithNewMetaCoin (59ms)


### PR DESCRIPTION
Fixes rendering the page via MkDocs

Before:
![Image 2022-02-13 at 9 39 08 PM](https://user-images.githubusercontent.com/7470690/153774169-8fbd8391-226b-4b00-a13d-572bbc2ef688.jpg)

After:
![Image 2022-02-13 at 9 42 53 PM](https://user-images.githubusercontent.com/7470690/153774240-c129073f-3aca-4752-917f-e66744bfc5c7.jpg)

