### PR TITLE
Remove extra bit before title in "using the debugger" page

### DIFF
--- a/src/docs/truffle/getting-started/using-the-truffle-debugger.md
+++ b/src/docs/truffle/getting-started/using-the-truffle-debugger.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Using the Truffle Debugger
+title: Using the Truffle Debugger
 layout: docs.hbs
 ---
 # Using the Truffle Debugger


### PR DESCRIPTION
It's causing it to show up wrong in the sidebar and it was bugging me.