### PR TITLE
Fix layer indexing for ganache-heading-row to make children links clickable

### DIFF
--- a/custom_theme/ganache.html
+++ b/custom_theme/ganache.html
@@ -33,12 +33,12 @@
 
     .ganache-heading-row {
 	 position: relative;
-     z-index: -100;
     }
     .ganache-heading-row .ganache-banner-image {
         margin: -6rem auto 0 auto;
         width: 80%;
         max-width: 912px;
+        z-index: -100;
     }
     @media (min-width: 768px) and (max-height: 767.98px) {
         .ganache-heading-row .ganache-banner-image {


### PR DESCRIPTION
Currently `.ganache-heading-row` layer is stacked in such a way that makes anchor buttons unclickable, This pull request will solve the issue. 