### PR TITLE
Document `truffle debug --url`

### DIFF
--- a/src/docs/truffle/getting-started/using-the-truffle-debugger.md
+++ b/src/docs/truffle/getting-started/using-the-truffle-debugger.md
@@ -24,6 +24,14 @@ Debug transactions involving contracts not in your project that are verified on 
 <a href="#debugging-external-contracts-with-verified-source">See below</a>.
 </p>
 
+<p class="alert alert-info m-t-2">
+<i class="far fa-info-circle"></i> <strong>
+New in Truffle v5.4.26: <code>truffle debug --url &lt;provider_url&gt;</code>.
+</strong>
+Debug transactions without needing a Truffle projct or config!
+<a href="#debugging-outside-of-a-truffle-project">See below</a>.
+</p>
+
 
 Debugging a transaction on the blockchain is different than debugging traditional applications (for instance, applications written in C++ or Javascript). When debugging a transaction on the blockchain, you're not running the code in real-time; instead, you're stepping over the historical execution of that transaction, and mapping that execution onto its associated code. This gives us many liberties in debugging, in that we can debug any transaction, any time, so long as we have the code and artifacts for the contracts the transaction interacted with. Think of these code and artifacts as akin to the debugging symbols needed by traditional debuggers.
 
@@ -116,7 +124,13 @@ You can specify the network you want to debug on with the `--network` option:
 $ truffle debug [<transaction hash>] --network <network>
 ```
 
-And if you want to debug your [Solidity test contracts](../testing/writing-tests-in-solidity), you can pass the `--compile-tests` option:
+Also, instead of `--network`, you can use `--url` with the URL of a provider; with this option, you can use Truffle Debugger outside of a Truffle project and without a Truffle config.  This is primarily useful with the [`--fetch-external`](#debugging-external-contracts-with-verified-source) option.
+
+```shell
+$ truffle debug [<transaction hash>] --url <provider_url>
+```
+
+If you want to debug your [Solidity test contracts](../testing/writing-tests-in-solidity), you can pass the `--compile-tests` option:
 
 ```shell
 $ truffle debug [<transaction hash>] --compile-tests
@@ -156,6 +170,10 @@ module.exports = {
   }
 }
 ```
+
+### Debugging outside of a Truffle project
+
+If you are outside of a Truffle project, you can still use `truffle debug` so long as you pass the `--url` option, giving the URL of a provider to connect to.  This is primarily useful with the `--fetch-external` option [described above](#debugging-external-contracts-with-verified-source).
 
 ## Debugging interface
 

--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -134,7 +134,7 @@ When specifying options in the config file *and* in the CLI, the options provide
 Interactively debug any transaction on the blockchain.
 
 ```shell
-truffle debug [<transaction_hash>] [--network <network>] [--fetch-external] [--compile-tests|--compile-all|--compile-none]
+truffle debug [<transaction_hash>] [--network <network>|--url <provider_url>] [--fetch-external] [--compile-tests|--compile-all|--compile-none]
 ```
 
 Will start an interactive debugging session on a particular transaction. Allows you to step through each action and replay. See [Using the truffle debugger](/docs/truffle/getting-started/using-the-truffle-debugger) for more details.
@@ -143,6 +143,7 @@ Options:
 
 - `<transaction_hash>`: Transaction ID to use for debugging. You can omit this to simply start the debugger and then load a transaction later.
 - `--network`: The network to connect to.
+- `--url`: Allows you to specify a provider URL to connect to, in place of `--network`.  If this option is used, the debugger may be used outside of a Truffle project.
 - `--fetch-external`: Allows the debugger to download source from source verification services to debug transactions involving external contracts. When used, a transaction hash is required. May be abbreviated `-x`.
 - `--compile-tests`: Allows the debugger to compile [Solidity test contracts](../testing/writing-tests-in-solidity). Implies `--compile-all`.
 - `--compile-all`: Forces the debugger to recompile all contracts, even when it would otherwise judge doing so unnecessary. Compilation results are not saved.


### PR DESCRIPTION
Fixes #1174.  Just some basic documentation.  I do worry a little about the proliferation of alert boxes at the top of the debugger page... do we want to start removing some of the older ones?