### PR TITLE
Added support for internationalisation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,8 +53,17 @@ markdown_extensions:
       permalink: true
 use_directory_urls: false
 plugins:
+  - i18n:
+      default_language: en
+      languages:
+          en:
+              name: English
+              build: true
+          fr:
+              name: French
+              build: true
+      material_alternate: true
   - search
-  - awesome-pages
   - macros:
       module_name: main
   - minify:


### PR DESCRIPTION
Added mkdocs-statis-i18n plugin. This requires the plugin to be installed with pip:

`pip install mkdocs-static-i18n`

Added initial configuration to mkdocs.yml for English and French languages for demo
purposes. At present the i18n seems to have some conflict with awesome-pages plugin.
In this branch the awesome-pages plugin has been disabled with the result that
navigation is perhaps broken. The root of this problem appears to be that both the
i18n and awesome-pages plugins rebuild the site from the source files.

There are also problems with styling that need to be rectified. This seem to be
related to the fact that the i18n plugin generates a site per language and will,
as a result, do some restructuring of the files and directories.