### PR TITLE
Removing Google Analytics script

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,9 +24,6 @@ theme:
   features:
     - navigation.tabs
   language: en
-google_analytics:
-  - UA-83874933-3
-  - auto
 copyright: Copyright &copy; 2016 - 2022 ConsenSys Software Inc.
 extra:
   generator: false


### PR DESCRIPTION
It's now being handled by Google Tag Manager (and thus needs to be removed to stop it double firing).