### PR TITLE
Fix for #1104 ( Nav bar is broken on desktop in smaller browser widths.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ site
 src/boxes/*/
 __pycache__
 .DS_Store
+env

--- a/src/blog/10-things-we-dont-do-that-make-working-at-truffle-awesome/index.md
+++ b/src/blog/10-things-we-dont-do-that-make-working-at-truffle-awesome/index.md
@@ -1,7 +1,6 @@
 ---
 title: 10 Things We Don't Do That Make Working at Truffle Awesome
-hide:
-  - navigation
+
 ---
 
 ![tapestry of Truffle team headshots](/img/blog/10-things-we-dont-do-that-make-working-at-truffle-awesome/layer-1.jpg)

--- a/src/blog/2020-is-finally-over-a-year-end-wrapup/index.md
+++ b/src/blog/2020-is-finally-over-a-year-end-wrapup/index.md
@@ -1,7 +1,6 @@
 ---
 title: 2020 is Finally Over - A Year End Wrapup
-hide:
-  - navigation
+
 ---
 
 ![Truffle End of Year Wrapup Banner](/img/blog/2020-is-finally-over-a-year-end-wrapup/blog-header.png)

--- a/src/blog/3-ways-enterprises-are-addressing-blockchain-privacy-concerns/index.md
+++ b/src/blog/3-ways-enterprises-are-addressing-blockchain-privacy-concerns/index.md
@@ -1,7 +1,6 @@
 ---
 title: 3 Ways Enterprises Are Addressing Blockchain Privacy Concerns
-hide:
-  - navigation
+
 ---
 
 [Blockchain has been touted as the great connector to integrate businesses under consortium networks](https://www.forbes.com/sites/andrewarnold/2019/02/21/why-2019-may-become-the-year-of-enterprise-blockchain/#66c9e516427e). It’s ability to verify data using smart contracts and provide transparency across network participants through immutable shared data has people talking about a technical revolution. However, this benefit has been a double-edged sword because the enterprise world is skeptical about sharing sensitive data on a ledger where the information cannot be deleted. The good news is, this year has seen numerous announcements of single and multi-party blockchain pilots by the Fortune 500 such as… [Starbucks](https://news.microsoft.com/transform/starbucks-turns-to-technology-to-brew-up-a-more-personal-connection-with-its-customers/) and [MetLife](https://www.forbes.com/sites/stevenehrlich/2019/06/19/metlife-plans-to-disrupt-2-7-trillion-life-insurance-industry-using-ethereum-blockchain/#3e9a87277022). Data privacy issues haven’t stopped them and the enterprise blockchain world has taken these steps to shift their thinking.

--- a/src/blog/5-trends-impacting-the-blockchain-developer-experience/index.md
+++ b/src/blog/5-trends-impacting-the-blockchain-developer-experience/index.md
@@ -1,7 +1,6 @@
 ---
 title: 5 Trends Impacting the Blockchain Developer Experience
-hide:
-  - navigation
+
 ---
 
 In this article we explore 5 trends impacting the developer-experience (or DX) when it comes to building blockchain-based solutions. Specifically, applications and services that leverage a blockchain or distributed ledger or as part of their overall architecture.

--- a/src/blog/a-sweet-upgradeable-contract-experience-with-openzeppelin-and-truffle/index.md
+++ b/src/blog/a-sweet-upgradeable-contract-experience-with-openzeppelin-and-truffle/index.md
@@ -1,7 +1,6 @@
 ---
 title: A Sweet Upgradeable Contract Experience with OpenZeppelin and Truffle
-hide:
-  - navigation
+
 ---
 
 ![Truffle + OpenZeppelin Banner](/img/blog/a-sweet-upgradeable-contract-experience-with-openzeppelin-and-truffle/blog-header.png)

--- a/src/blog/an-easier-way-to-deploy-your-smart-contracts/index.md
+++ b/src/blog/an-easier-way-to-deploy-your-smart-contracts/index.md
@@ -1,7 +1,6 @@
 ---
 title: An Easier Way to Deploy Your Smart Contracts
-hide:
-  - navigation
+
 ---
 
 **TL;DR** - Deploying your smart contracts shouldn't be difficult, and the process should be flexible. I give a sneak peek at the next feature we're building: an **easy to use interface to deploy your Truffle projects with [Truffle Teams](/docs/teams/overview)**! It's going to be awesome, and **you can be the first to use it**! I'll be giving a **hands-on workshop from 9AM-12PM on Friday, August 2nd, at [TruffleCon 2019](/trufflecon2019)** that will walk you through through the entire Truffle Teams lifecycle, including the **never-before-used Deployments interface**! See you there!

--- a/src/blog/announcing-collaboration-with-filecoin/index.md
+++ b/src/blog/announcing-collaboration-with-filecoin/index.md
@@ -1,7 +1,6 @@
 ---
 title: Announcing Collaboration with Filecoin - Big Integrations Coming
-hide:
-  - navigation
+
 ---
 
 ![Filecoin Collab Banner](/img/blog/announcing-collaboration-with-filecoin/blog-header.png)

--- a/src/blog/announcing-full-portable-solidity-debugger/index.md
+++ b/src/blog/announcing-full-portable-solidity-debugger/index.md
@@ -1,7 +1,6 @@
 ---
 title: Announcing our Fully Featured, Portable Solidity Debugger
-hide:
-  - navigation
+
 ---
 
 Every one at Truffle is giddy right now. 

--- a/src/blog/axonis-enterprise-use-of-truffle/index.md
+++ b/src/blog/axonis-enterprise-use-of-truffle/index.md
@@ -1,7 +1,6 @@
 ---
 title: Axoni's Enterprise Use of Truffle
-hide:
-  - navigation
+
 ---
 
 ![Truffle + Axoni](/img/blog/axonis-enterprise-use-of-truffle/truffle-axoni.png)

--- a/src/blog/best-methods-to-understand-blockchain-if-youre-not-a-developer/index.md
+++ b/src/blog/best-methods-to-understand-blockchain-if-youre-not-a-developer/index.md
@@ -1,7 +1,6 @@
 ---
 title: The Best Methods to Understand Blockchain Technology if You’re Not A Developer
-hide:
-  - navigation
+
 ---
 
 As a non-technical person, it feels like it takes 1.21 gigawatts to keep up with the speed of technology - even Doc Brown himself couldn't have predicted all of the technological advancements with his flux capacitor. Not only are we trying to keep up with technologies like blockchain, machine learning, and AI, but we have an overwhelming amount of information on the web all at the click of a mouse. It's overwhelming to the point that it's difficult to even know where to begin. However, online blockchain educational materials have started to ramp up. As I write this, I'm confident I'll start seeing “ Blockchain for dummies” online course advertisements on my browser (Opt-in, of course, because I'm using Brave). Mind-blowing! Let me help you begin by slowing down in order to speed up effectively.

--- a/src/blog/blockchain-will-cure-cancer/index.md
+++ b/src/blog/blockchain-will-cure-cancer/index.md
@@ -1,7 +1,6 @@
 ---
 title: Blockchain Will Cure Cancer
-hide:
-  - navigation
+
 ---
 
 <p style="width: 40%; float: left; margin-right: 1rem;">

--- a/src/blog/branching-out-announcing-tezos-support-in-truffle/index.md
+++ b/src/blog/branching-out-announcing-tezos-support-in-truffle/index.md
@@ -1,7 +1,6 @@
 ---
 title: Branching Out - Announcing Tezos Support in Truffle
-hide:
-  - navigation
+
 ---
 
 ![Announcing Truffle Integration](/img/blog/branching-out-announcing-tezos-support-in-truffle/chameleon-t3-truffle-blog-header.png)

--- a/src/blog/branching-out-phase-2-of-corda-flavored-ganache/index.md
+++ b/src/blog/branching-out-phase-2-of-corda-flavored-ganache/index.md
@@ -1,7 +1,6 @@
 ---
 title: Branching Out - Phase 2 of Corda-flavored Ganache
-hide:
-  - navigation
+
 ---
 
 ![Branching out to Corda-flavored Ganache](/img/blog/branching-out-phase-2-of-corda-flavored-ganache/chameleon-corda-truffle-blog-header.png)

--- a/src/blog/bring-your-own-ci-byoci-with-truffle-teams/index.md
+++ b/src/blog/bring-your-own-ci-byoci-with-truffle-teams/index.md
@@ -1,7 +1,6 @@
 ---
 title: Bring Your Own CI (BYOCI) with Truffle Teams
-hide:
-  - navigation
+
 ---
 
 Truffle Teams has always offered an internal continuous integration (CI) service. This service is great for getting up and running quickly since it requires no configuration to run your Truffle tests.

--- a/src/blog/crytic-continuous-assurance-for-smart-contracts/index.md
+++ b/src/blog/crytic-continuous-assurance-for-smart-contracts/index.md
@@ -1,7 +1,6 @@
 ---
 title: Crytic - Continuous Assurance for Smart Contracts
-hide:
-  - navigation
+
 ---
 
 We are proud to announce our new Smart contract security product: [https://crytic.io/](https://crytic.io/). Crytic provides continuous assurance for smart contracts. The platform reports build status on every commit and runs a suite of security analyses for immediate feedback.

--- a/src/blog/debug-quickly-and-in-context-with-truffle-teams-new-debugger/index.md
+++ b/src/blog/debug-quickly-and-in-context-with-truffle-teams-new-debugger/index.md
@@ -1,7 +1,6 @@
 ---
 title: Debug Quickly and in Context with Truffle Teams New Debugger
-hide:
-  - navigation
+
 ---
 
 ![Truffle Teams Debugger Banner](/img/blog/debug-quickly-and-in-context-with-truffle-teams-new-debugger/blog-header.png)

--- a/src/blog/debugging-verified-external-contracts-with-truffle-debugger/index.md
+++ b/src/blog/debugging-verified-external-contracts-with-truffle-debugger/index.md
@@ -1,7 +1,6 @@
 ---
 title: Debugging verified external contracts with Truffle Debugger
-hide:
-  - navigation
+
 ---
 
 ![Truffle Teams Redesign Banner](/img/blog/debugging-verified-external-contracts-with-truffle-debugger/blog-header.png)

--- a/src/blog/designing-the-ganache-logo/index.md
+++ b/src/blog/designing-the-ganache-logo/index.md
@@ -1,7 +1,6 @@
 ---
 title: Designing the Ganache Logo
-hide:
-  - navigation
+
 ---
 
 Last week we released [Ganache](/ganache), a personal blockchain for Ethereum development. Many of you commented on the design of the landing page and logo, but just how did the gooey cube come to be? Let's take a trip through the 30+ iterations that led to our newest confection.

--- a/src/blog/develop-using-fluidity-truffle-box/index.md
+++ b/src/blog/develop-using-fluidity-truffle-box/index.md
@@ -1,7 +1,6 @@
 ---
 title: Develop using Fluidity Truffle Box
-hide:
-  - navigation
+
 ---
 
 **TLDR;** Fluidity has a pretty awesome truffle-box with lots of goodies to build secure, well-tested smart contracts. With two simple commands, you’ll be set up for development using these testing and security tools preconfigured.

--- a/src/blog/drizzle-150-a-new-beginning/index.md
+++ b/src/blog/drizzle-150-a-new-beginning/index.md
@@ -1,7 +1,6 @@
 ---
 title: Drizzle 1.5.0 - A new beginning
-hide:
-  - navigation
+
 ---
 
 <figure>

--- a/src/blog/drizzle-reactive-ethereum-data-for-front-ends/index.md
+++ b/src/blog/drizzle-reactive-ethereum-data-for-front-ends/index.md
@@ -1,7 +1,6 @@
 ---
 title: Drizzle - Reactive Ethereum Data for Front-ends
-hide:
-  - navigation
+
 ---
 
 Today we're proud to announce the addition of a new product to the Truffle Suite: Drizzle. Drizzle is a collection of front-end libraries that make writing dapp front-ends easier and more predictable.

--- a/src/blog/drizzle-vue-a-truffle-story/index.md
+++ b/src/blog/drizzle-vue-a-truffle-story/index.md
@@ -1,7 +1,6 @@
 ---
 title: Drizzle Vue - A Truffle Story
-hide:
-  - navigation
+
 ---
 
 ![Drizzle + Vue = <3](/img/blog/drizzle-vue-a-truffle-story/title-image.png)

--- a/src/blog/ethereum-gas-exactimation/index.md
+++ b/src/blog/ethereum-gas-exactimation/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ethereum Gas Exactimation
-hide:
-  - navigation
+
 ---
 
 In Ethereum, estimating gas for a given transaction is a tricky problem to solve (especially when attempting to maintain [EIP-114](https://github.com/ethereum/EIPs/issues/114) compliance). Most of the well-known Ethereum implementations like Geth<sup>¹</sup> and Parity<sup>²</sup> use interval halving (binary search) to estimate gas by running transactions through the EVM until an approximate estimation converges.

--- a/src/blog/first-ever-truffle-retreat/index.md
+++ b/src/blog/first-ever-truffle-retreat/index.md
@@ -1,7 +1,6 @@
 ---
 title: Our First Ever Truffle Retreat
-hide:
-  - navigation
+
 ---
 
 ![Truffle](/img/blog/first-ever-truffle-retreat/medium-truffle-retreat.jpg)

--- a/src/blog/get-a-birds-eye-view-with-truffle-teams-new-dashboard/index.md
+++ b/src/blog/get-a-birds-eye-view-with-truffle-teams-new-dashboard/index.md
@@ -1,7 +1,6 @@
 ---
 title: Get a Bird's Eye View with Truffle Teams' New Dashboard
-hide:
-  - navigation
+
 ---
 
 <figure>

--- a/src/blog/github-repository-moved/index.md
+++ b/src/blog/github-repository-moved/index.md
@@ -1,7 +1,6 @@
 ---
 title: We've moved our github repo!
-hide:
-  - navigation
+
 ---
 
 We recently released [Truffle 3.0](https://github.com/trufflesuite/truffle/releases/tag/v3.0.2) in February to [much fanfare](/dashboard). As part of that release we separated our codebase into multiple different modules to make integrating with Truffle easier. Those modules now live in the github repository [https://github.com/trufflesuite](https://github.com/trufflesuite), which hints at our broader mission of providing a comprehensive suite of tools for Ethereum development.

--- a/src/blog/how-ethical-advertising-will-transform-the-blockchain-industry/index.md
+++ b/src/blog/how-ethical-advertising-will-transform-the-blockchain-industry/index.md
@@ -1,7 +1,6 @@
 ---
 title: How Ethical Advertising Will Transform the Blockchain Industry
-hide:
-  - navigation
+
 ---
 
 ![GitCoin](/img/blog/how-ethical-advertising-will-transform-the-blockchain-industry/pasted image 0-5.png)

--- a/src/blog/how-the-arrival-of-web-3-0-is-transforming-traditional-business-models/index.md
+++ b/src/blog/how-the-arrival-of-web-3-0-is-transforming-traditional-business-models/index.md
@@ -1,7 +1,6 @@
 ---
 title: How the Arrival of Web 3.0 is Transforming Traditional Business Models
-hide:
-  - navigation
+
 ---
 
 Although the Internet continues to drive digital transformation, the technology operates far beyond its original parameters. Since its inception over two decades ago, the web has been subject to increasing levels of centralization and mass surveillance. As a result, large corporations, governments, and media outlets remain the primary beneficiaries of an infrastructure meant to serve all of humanity. Herein lies the problem with the current Internet ecosystem, also known as Web 2.0.

--- a/src/blog/how-to-get-your-boss-to-send-you-to-trufflecon/index.md
+++ b/src/blog/how-to-get-your-boss-to-send-you-to-trufflecon/index.md
@@ -1,7 +1,6 @@
 ---
 title: How to get your boss to send you to TruffleCon
-hide:
-  - navigation
+
 ---
 
 Last year [Truffle Suite](/) launched [TruffleCon](/trufflecon2019), an event designed for the Truffle community and those interested in building world-changing applications powered by decentralized technologies. The event was received with an overwhelmingly positive response. TruffleCon attracted 250 attendees, 53 speakers, and 2 locations. After such a successful inaugural event, the team immediately started planning an even bigger and better Trufflecon for 2019.

--- a/src/blog/how-were-making-installation-issues-a-thing-of-the-past/index.md
+++ b/src/blog/how-were-making-installation-issues-a-thing-of-the-past/index.md
@@ -1,7 +1,6 @@
 ---
 title: How we're making installation issues a thing of the past
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-info">

--- a/src/blog/introducing-ganache-7/index.md
+++ b/src/blog/introducing-ganache-7/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ganache 7 Ethereum Simulator - Building on Web3 is now easier and faster than ever before
-hide:
-  - navigation
+
 ---
 
 ![ganache v7 banner](./ganache-v7.png)

--- a/src/blog/introducing-truffle-dashboard/index.md
+++ b/src/blog/introducing-truffle-dashboard/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introducing Truffle Dashboard - Stop copy + pasting your private keys!
-hide:
-  - navigation
+
 ---
 
 ![truffle dashboard - banner](./truffle-dashboard-private-keys.png)

--- a/src/blog/introducing-truffle-db-part-1/index.md
+++ b/src/blog/introducing-truffle-db-part-1/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introducing Truffle DB, Part 1 - Artifact archeology
-hide:
-  - navigation
+
 ---
 
 ## Introducing Truffle DB, part 1: Artifact archeology

--- a/src/blog/introducing-truffle-db-part-2/index.md
+++ b/src/blog/introducing-truffle-db-part-2/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introducing Truffle DB, part 2 - 'Weight and Switch'
-hide:
-  - navigation
+
 ---
 
 Welcome back! If you missed the [first part](/blog/introducing-truffle-db-part-1) of this post, you may want to read it to learn more about Truffle’s contract artifacts, their current limitations, and why we seek to build a better solution.

--- a/src/blog/iterate-faster-with-truffle-teams/index.md
+++ b/src/blog/iterate-faster-with-truffle-teams/index.md
@@ -1,7 +1,6 @@
 ---
 title: Iterate Faster with Truffle Teams
-hide:
-  - navigation
+
 ---
 
 Consider the amount of context switching required to develop a dapp: you’re writing Solidity one minute, writing tests another, debugging those results--it’s easy to get lost! These switches carry a cognitive load and when errors equal a loss of ETH we need all the help we can get. I’m happy to inform you Truffle Teams can help reduce context switching and help you or your team iterate faster.

--- a/src/blog/learn-ethereum-the-fun-way-with-our-pet-shop-tutorial/index.md
+++ b/src/blog/learn-ethereum-the-fun-way-with-our-pet-shop-tutorial/index.md
@@ -1,7 +1,6 @@
 ---
 title: Learn Ethereum The Fun Way with our Pet Shop Tutorial
-hide:
-  - navigation
+
 ---
 
 Here at Truffle we want to make Ethereum development accessible to developers of all stripes. To that end, today we're releasing a new tutorial called [Pet Shop](/tutorial). It covers the entire local development process, start to finish. For added fun, we've tied the whole thing together within the narrative of creating a pet adoption dapp for a local pet shop owner.

--- a/src/blog/one-hundred-documentation-pull-requests/index.md
+++ b/src/blog/one-hundred-documentation-pull-requests/index.md
@@ -1,7 +1,6 @@
 ---
 title: One hundred documentation pull requests? Yes please.
-hide:
-  - navigation
+
 ---
 
 Greetings! The Truffle team has been growing over the course of the last year. From a single developer, we are now a team of five (soon to be even more), which means that we can spread the work around.

--- a/src/blog/open-call-for-contributions-truffle-pegasys-eea-private-transactions/index.md
+++ b/src/blog/open-call-for-contributions-truffle-pegasys-eea-private-transactions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Open call for contributions by Truffle + PegaSys - EEA private transactions
-hide:
-  - navigation
+
 ---
 
 # Open call for contributions by Truffle + PegaSys: EEA private transactions

--- a/src/blog/removing-installation-issues-continued-testrpc/index.md
+++ b/src/blog/removing-installation-issues-continued-testrpc/index.md
@@ -1,7 +1,6 @@
 ---
 title: Removing installation issues, con't - TestRPC
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-info">

--- a/src/blog/sandbox-forking-with-truffle-teams/index.md
+++ b/src/blog/sandbox-forking-with-truffle-teams/index.md
@@ -1,7 +1,6 @@
 ---
 title: Simulate Live Networks with Forked Sandboxes
-hide:
-  - navigation
+
 ---
 
 <figure>

--- a/src/blog/stack-tracing-with-truffle-test/index.md
+++ b/src/blog/stack-tracing-with-truffle-test/index.md
@@ -1,7 +1,6 @@
 ---
 title: Stack Tracing with Truffle Test
-hide:
-  - navigation
+
 ---
 
 <figure>

--- a/src/blog/sunsetting-truffle-teams/index.md
+++ b/src/blog/sunsetting-truffle-teams/index.md
@@ -1,7 +1,6 @@
 ---
 title: Sunsetting Truffle Teams
-hide:
-  - navigation
+
 ---
 
 ![Sunsetting Truffle Teams Banner](/img/blog/sunsetting-truffle-teams/blog-header.png)

--- a/src/blog/take-a-dive-into-truffle-5/index.md
+++ b/src/blog/take-a-dive-into-truffle-5/index.md
@@ -1,7 +1,6 @@
 ---
 title: Take a Dive into Truffle 5
-hide:
-  - navigation
+
 ---
 
 ![Take a Dive into Truffle 5 Banner](/img/blog/take-a-dive-into-truffle-5/blog-header.png)

--- a/src/blog/take-control-of-your-deployments-with-truffle-teams/index.md
+++ b/src/blog/take-control-of-your-deployments-with-truffle-teams/index.md
@@ -1,7 +1,6 @@
 ---
 title: Take Control of Your Deployments with Truffle Teams
-hide:
-  - navigation
+
 ---
 
 ![Truffle Teams Deployments Banner](/img/blog/easily-deploy-your-smart-contracts-with-truffle-teams/truffle-teams-deployments-banner.png)

--- a/src/blog/testrpc-is-now-ganache/index.md
+++ b/src/blog/testrpc-is-now-ganache/index.md
@@ -1,7 +1,6 @@
 ---
 title: TestRPC is now Ganache
-hide:
-  - navigation
+
 ---
 
 Have you been looking for the TestRPC recently and haven't been able to find it?

--- a/src/blog/the-best-things-to-do-in-seattle-during-trufflecon/index.md
+++ b/src/blog/the-best-things-to-do-in-seattle-during-trufflecon/index.md
@@ -1,7 +1,6 @@
 ---
 title: The Best Things to do in Seattle During TruffleCon
-hide:
-  - navigation
+
 ---
 
 ![river view at Marymoor Park](/img/blog/the-best-things-to-do-in-seattle-during-trufflecon/layer-1.jpg)

--- a/src/blog/the-best-ways-to-contribute-to-truffle/index.md
+++ b/src/blog/the-best-ways-to-contribute-to-truffle/index.md
@@ -1,7 +1,6 @@
 ---
 title: The Best Ways to Contribute to Truffle
-hide:
-  - navigation
+
 ---
 
 Have you ever thought about contributing to Truffle? All of us at Truffle really enjoy producing free and open source software, and it is especially fun when many of you in the community contribute. User contributions make life easier for us, make our work more enjoyable by showing that you’re engaged, and often give us a chance to learn from those that offer code to the project. We’d absolutely love any and all developers to contribute to our project. The following are a few ways that you can get involved.

--- a/src/blog/the-blockchain-problem-that-ens-solves/index.md
+++ b/src/blog/the-blockchain-problem-that-ens-solves/index.md
@@ -1,7 +1,6 @@
 ---
 title: The Blockchain UI Problem that ENS Solves
-hide:
-  - navigation
+
 ---
 
 The blockchain world has a UI problem. This is what an Ethereum receiving address looks like:

--- a/src/blog/token-taxonomy-framework/index.md
+++ b/src/blog/token-taxonomy-framework/index.md
@@ -1,7 +1,6 @@
 ---
 title: Token Taxonomy Framework
-hide:
-  - navigation
+
 ---
 
 To some, the sudden rise of Tokens in the blockchain dialog comes as a surprise. However, tokens have always been the bedrock of the blockchain movement. The introduction of SmartContract by Ethereum quickly overshadowed them, particularly in enterprise contexts. The capabilities of Smart Contracts and the broad acceptance of them, thanks to companies like Truffle, blazed a trail forward and we all went along. It wasn’t until we got halfway up the trail that someone turned around and asked, “did we pack any trail mix?”

--- a/src/blog/truffle-320-released/index.md
+++ b/src/blog/truffle-320-released/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle 3.2.0 released
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-info" style="margin-top: -2rem; margin-bottom: 3rem;">

--- a/src/blog/truffle-and-ganache-now-come-in-filecoin-flavor/index.md
+++ b/src/blog/truffle-and-ganache-now-come-in-filecoin-flavor/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle and Ganache now come in Filecoin Flavor
-hide:
-  - navigation
+
 ---
 
 ![Filecoin Collab Banner with Ganache](/img/blog/truffle-and-ganache-now-come-in-filecoin-flavor/blog-header.png)

--- a/src/blog/truffle-and-infura-support-arbitrum/index.md
+++ b/src/blog/truffle-and-infura-support-arbitrum/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle and Infura Now Support Arbitrum
-hide:
-  - navigation
+
 ---
 
 ![Truffle, Arbitrum Collab Image](/img/blog/truffle-and-infura-support-arbitrum/blog-header.png)

--- a/src/blog/truffle-and-infura-support-optimism/index.md
+++ b/src/blog/truffle-and-infura-support-optimism/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle and Infura Now Support Optimism
-hide:
-  - navigation
+
 ---
 
 ![Truffle, Optimism Collab Image](/img/blog/truffle-and-infura-support-optimism/blog-header.png)

--- a/src/blog/truffle-and-infura-support-polygon/index.md
+++ b/src/blog/truffle-and-infura-support-polygon/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle and Infura Now Support Polygon
-hide:
-  - navigation
+
 ---
 
 ![Truffle, Infura, and Polygon Collab Image](/img/blog/truffle-and-infura-support-polygon/blog-header.png)

--- a/src/blog/truffle-boxes-making-life-sweeter/index.md
+++ b/src/blog/truffle-boxes-making-life-sweeter/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Boxes - Making Life Sweeter
-hide:
-  - navigation
+
 ---
 
 When users begin developing on Ethereum, the first question they ask is, "Where do I start?". In the past, there hasn't been an easy answer: the answer generally consisted of many flavors of "it depends", and usually led to an investigation of what the user was trying to build, a general overview of their development skills, their knowledge of Ethereum, and the libraries and tools they're already most comfortable with. When determining how the Truffle team can help in this process, it quickly became apparent that what our users needed were examples. _Many of them._ So, being the upstanding community members we are, we set out to create those example, and today, we're happy to show you what we've accomplished.

--- a/src/blog/truffle-teams-gets-a-new-look/index.md
+++ b/src/blog/truffle-teams-gets-a-new-look/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Teams Gets a New Look!
-hide:
-  - navigation
+
 ---
 
 ![Truffle Teams Redesign Banner](/img/blog/truffle-teams-gets-a-new-look/banner.png)

--- a/src/blog/truffle-teams-now-supports-private-repositories/index.md
+++ b/src/blog/truffle-teams-now-supports-private-repositories/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Teams Now Supports Private Repositories
-hide:
-  - navigation
+
 ---
 
 Thanks to the awesome work of [@nicholasjpaterno](https://github.com/nicholasjpaterno), you can now integrate private repositories with Truffle Teams! This will eventually be a premium feature, but we're releasing it for free while the product is still in beta.

--- a/src/blog/truffle-v5-has-arrived/index.md
+++ b/src/blog/truffle-v5-has-arrived/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle v5 has arrived!
-hide:
-  - navigation
+
 ---
 
 We have just released the most awaited version of Truffle just in time for the

--- a/src/blog/try-new-features-first-with-truffle-teams-early-access/index.md
+++ b/src/blog/try-new-features-first-with-truffle-teams-early-access/index.md
@@ -1,7 +1,6 @@
 ---
 title: Try New Features First with Truffle Teams Early Access
-hide:
-  - navigation
+
 ---
 
 ![Truffle Teams Early Access Banner](/img/blog/try-new-features-first-with-truffle-teams-early-access/blog-header.png)

--- a/src/blog/unwrap-the-corda-flavored-ganache-beta/index.md
+++ b/src/blog/unwrap-the-corda-flavored-ganache-beta/index.md
@@ -1,7 +1,6 @@
 ---
 title: Unwrap the Corda Flavored Ganache Beta
-hide:
-  - navigation
+
 ---
 
 ![Truffle Teams Deployments Banner](/img/blog/unwrap-the-corda-flavored-ganache-beta/corda-ganache-beta-blog-banner.png)

--- a/src/blog/upcoming-improvements-to-encoding-and-decoding/index.md
+++ b/src/blog/upcoming-improvements-to-encoding-and-decoding/index.md
@@ -1,7 +1,6 @@
 ---
 title: Upcoming improvements to encoding and decoding
-hide:
-  - navigation
+
 ---
 
 When you’re writing, running, or debugging your smart contract, you don’t want to have to deal with raw binary data. Truffle––and Ganache and Drizzle––already contain a number of encoding and decoding features to help you interact with your contract and understand what you’re seeing. But luckily, encoding and decoding are about to become even more robust, informative, and usable.

--- a/src/blog/using-the-ens-integration/index.md
+++ b/src/blog/using-the-ens-integration/index.md
@@ -1,7 +1,6 @@
 ---
 title: Using Truffle's ENS Integration
-hide:
-  - navigation
+
 ---
 
 **By Tyler Feickert, Blockchain Tools Engineer at Truffle**

--- a/src/blog/using-truffle-to-interact-with-chainlink-smart-contracts/index.md
+++ b/src/blog/using-truffle-to-interact-with-chainlink-smart-contracts/index.md
@@ -1,7 +1,6 @@
 ---
 title: Using Truffle to interact with Chainlink Smart Contracts
-hide:
-  - navigation
+
 ---
 
 ![Truffle + Chainlink](/img/blog/using-truffle-to-interact-with-chainlink-smart-contracts/chainlink-az.png)

--- a/src/blog/why-i-love-trufflecon/index.md
+++ b/src/blog/why-i-love-trufflecon/index.md
@@ -1,7 +1,6 @@
 ---
 title: Why I love TruffleCon
-hide:
-  - navigation
+
 ---
 
 **By Josh Quintal, Head of Product & Marketing**

--- a/src/blog/why-were-organizing-trufflecon-2018/index.md
+++ b/src/blog/why-were-organizing-trufflecon-2018/index.md
@@ -1,7 +1,6 @@
 ---
 title: Why We're Organizing TruffleCon 2018
-hide:
-  - navigation
+
 ---
 
 ![TruffleCon 2018](/img/blog/why-were-organizing-trufflecon-2018/trufflecon2018header.jpg)

--- a/src/blog/you-can-now-make-your-own-truffle-box/index.md
+++ b/src/blog/you-can-now-make-your-own-truffle-box/index.md
@@ -1,7 +1,6 @@
 ---
 title: You Can Now Make Your Own Truffle Box
-hide:
-  - navigation
+
 ---
 
 Two months ago we unveiled official integration with **Truffle Boxes**, example Ethereum applications and/or boilerplates that put complimentary tools and libraries into sweet, easily-downloadable packages. In addition to rolling out some official boxes, [Status.im](https://status.im/) released [the first community-supported box](/boxes/status).

--- a/src/blog/you-decide-pipeline-or-table-view-in-truffle-teams-deployments-manager/index.md
+++ b/src/blog/you-decide-pipeline-or-table-view-in-truffle-teams-deployments-manager/index.md
@@ -1,7 +1,6 @@
 ---
 title: You Decide - Pipeline or Table View in Truffle Teams' Refreshed Deployments Manager
-hide:
-  - navigation
+
 ---
 
 ![Truffle Teams Deployments Refresh Banner](/img/blog/you-decide-pipeline-or-table-view-in-truffle-teams-deployments-manager/blog-header.png)

--- a/src/boxes/box.html.jinja2
+++ b/src/boxes/box.html.jinja2
@@ -1,6 +1,5 @@
 ---
-hide:
-  - navigation
+
 ---
 
 {{ readme }}

--- a/src/guides/building-dapps-for-quorum-private-enterprise-blockchains/index.md
+++ b/src/guides/building-dapps-for-quorum-private-enterprise-blockchains/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
 hide:
-  - navigation
   - toc
 ---
 

--- a/src/guides/building-testing-frontend-app-truffle-3/index.md
+++ b/src/guides/building-testing-frontend-app-truffle-3/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-info">

--- a/src/guides/bundling-with-webpack/index.md
+++ b/src/guides/bundling-with-webpack/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained. Use at your own risk!</p>

--- a/src/guides/chain-forking-exploiting-the-dao/index.md
+++ b/src/guides/chain-forking-exploiting-the-dao/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained. Use at your own risk!</p>

--- a/src/guides/configuring-visual-studio-code/index.md
+++ b/src/guides/configuring-visual-studio-code/index.md
@@ -1,7 +1,6 @@
 ---
 title: Configuring Visual Studio code for Ethereum Blockchain Development
-hide:
-  - navigation
+
 ---
 
 This post was originally published by David Burela on his blog [Burela's House-o-blog](https://davidburela.wordpress.com/2016/11/18/configuring-visual-studio-code-for-ethereum-blockchain-development/). Big thanks to David for allowing us publish it here!

--- a/src/guides/creating-a-cli-with-truffle-3/index.md
+++ b/src/guides/creating-a-cli-with-truffle-3/index.md
@@ -1,7 +1,6 @@
 ---
 title: Creating an Ethereum-enabled command line tool with Truffle 3.0
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained. Use at your own risk!</p>

--- a/src/guides/debugger-variable-inspection/index.md
+++ b/src/guides/debugger-variable-inspection/index.md
@@ -1,7 +1,6 @@
 ---
 title: Variable Inspection - Going Deeper with the Truffle Solidity Debugger
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-info">

--- a/src/guides/debugging-an-example-smart-contract/index.md
+++ b/src/guides/debugging-an-example-smart-contract/index.md
@@ -1,7 +1,6 @@
 ---
 title: Debugging an Example Smart Contract
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-info">

--- a/src/guides/deploying-to-the-live-network/index.md
+++ b/src/guides/deploying-to-the-live-network/index.md
@@ -1,7 +1,6 @@
 ---
 title: Deploying to the Live Network
-hide:
-  - navigation
+
 ---
 
 When you're finished developing your contracts and would like others to use them, the next step is to deploy them to the live network. By now you will have been working on a development network like [Ganache](/ganache), and you will have noticed Truffle is set up to support that by default. Deploying to the live network -- or any other network -- will require that you first connect one of the [many Ethereum clients](https://ethdocs.org/en/latest/ethereum-clients/) to your network of choice, as well as configure Truffle correctly.

--- a/src/guides/drizzle-and-contract-events/index.md
+++ b/src/guides/drizzle-and-contract-events/index.md
@@ -1,7 +1,6 @@
 ---
 title: Drizzle and Contract Events
-hide:
-  - navigation
+
 ---
 
 # Drizzle and Contract Events

--- a/src/guides/drizzle-and-react-native/index.md
+++ b/src/guides/drizzle-and-react-native/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained. Use at your own risk!</p>

--- a/src/guides/ethereum-devops-truffle-testrpc-vsts/index.md
+++ b/src/guides/ethereum-devops-truffle-testrpc-vsts/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained. Use at your own risk!</p>

--- a/src/guides/ethereum-overview/index.md
+++ b/src/guides/ethereum-overview/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ethereum Overview
-hide:
-  - navigation
+
 ---
 
 You may have heard the terms "blockchain" and "smart contract" floating around, but what do they actually mean? In this tutorial, we'll demystify the jargon, show you practical blockchain solutions, and give you direction on how to create an application that takes advantage of the blockchain.

--- a/src/guides/getting-started-with-drizzle-and-react/index.md
+++ b/src/guides/getting-started-with-drizzle-and-react/index.md
@@ -1,6 +1,5 @@
 ---
-hide:
-  - navigation
+
 ---
 
 # Getting Started with Drizzle and React

--- a/src/guides/how-to-install-truffle-and-testrpc-on-windows-for-blockchain-development/index.md
+++ b/src/guides/how-to-install-truffle-and-testrpc-on-windows-for-blockchain-development/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained.<br/><br/>David Burela now recommends a different, updated way of doing this on his blog, which you can check out here: <a target="_blank" href="https://davidburela.wordpress.com/2017/05/12/how-to-install-truffle-testrpc-on-ubuntu-or-windows-10-with-windows-subsystem-for-linux/">How to install Truffle & TestRPC on Ubuntu or Windows 10 with ?"Windows subsystem for Linux"</a></p>

--- a/src/guides/learn-how-to-deploy-with-truffle-teams/index.md
+++ b/src/guides/learn-how-to-deploy-with-truffle-teams/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 In this tutorial, you'll learn how to deploy your smart contracts to a public Ethereum network using Truffle Teams.

--- a/src/guides/package-management/index.md
+++ b/src/guides/package-management/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained. Use at your own risk!</p>

--- a/src/guides/pet-shop/index.md
+++ b/src/guides/pet-shop/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 ![Ethereum Pet Shop](/img/tutorials/pet-shop/petshop.png)

--- a/src/guides/robust-smart-contracts-with-openzeppelin/index.md
+++ b/src/guides/robust-smart-contracts-with-openzeppelin/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 ![OpenZeppelin](/img/tutorials/open-zeppelin/oz-logo.png)

--- a/src/guides/scribble/index.md
+++ b/src/guides/scribble/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 # Supercharge your test suite with Scribble!

--- a/src/guides/solidity-unit-tests/index.md
+++ b/src/guides/solidity-unit-tests/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 This is a beta document and refers to the `beta` version of Truffle. The following features will not work unless you are using Truffle Beta.

--- a/src/guides/testing-for-throws-in-solidity-tests/index.md
+++ b/src/guides/testing-for-throws-in-solidity-tests/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained. Use at your own risk!</p>

--- a/src/guides/truffle-and-metamask/index.md
+++ b/src/guides/truffle-and-metamask/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <div class="alert alert-info">

--- a/src/guides/upgrading-from-truffle-2-to-3/index.md
+++ b/src/guides/upgrading-from-truffle-2-to-3/index.md
@@ -1,7 +1,6 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
+
 ---
 
 <p class="alert alert-warning"><i class="far fa-exclamation-triangle"></i> <strong>Archived:</strong> This tutorial has been archived and may not work as expected; versions are out of date, methods and workflows may have changed. We leave these up for historical context and for any universally useful information contained. Use at your own risk!</p>

--- a/src/guides/using-infura-custom-provider/index.md
+++ b/src/guides/using-infura-custom-provider/index.md
@@ -1,7 +1,6 @@
 ---
 title: Using Infura (or a custom provider)
-hide:
-  - navigation
+
 ---
 
 ![Infura Truffle logos](/img/tutorials/infura/infura-truffle.png)

--- a/src/guides/web3-development-stack/index.md
+++ b/src/guides/web3-development-stack/index.md
@@ -1,7 +1,6 @@
 ---
 title: The Web3 development stack
-hide:
-  - navigation
+
 ---
 
 ![Web3 Development Stack header](./web3-dev-stack_blog-header.png)

--- a/src/tutorial/index.md
+++ b/src/tutorial/index.md
@@ -1,7 +1,5 @@
 ---
 title: Truffle Suite
-hide:
-  - navigation
 ---
 
 <style>


### PR DESCRIPTION
Removes all navigation hide lines from documents in guides, blogs, tutorials, and file box.html.jinja2. 
```
hide:
  - navigation
```
This fixes the issue where the navigation sidebar is not displaying on smaller viewports.
