### PR TITLE
fix #1217: Exclude irrelevant results from search results

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,13 @@ markdown_extensions:
 use_directory_urls: true
 plugins:
   - search
+  - exclude-search:
+      exclude:
+        - blog/*
+        - events/*
+        - staff/*
+        - trufflecon2020/*
+      exclude-unreferenced: true
   - awesome-pages
   - macros:
       module_name: main


### PR DESCRIPTION
The mkdocs-exclude-search plugin was installed (https://github.com/chrieke/mkdocs-exclude-search)

The following folders were excluded from the general search:
      exclude:
        - blog/*
        - events/*
        - staff/*
        - trufflecon2020/*