### PR TITLE
fix #1217: Exclude irrelevant results from search results

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,13 @@ markdown_extensions:
 use_directory_urls: true
 plugins:
   - search
+  - exclude-search:
+      exclude:
+        - blog/*
+        - events/*
+        - staff/*
+        - trufflecon2020/*
+      exclude-unreferenced: true
   - awesome-pages
   - macros:
       module_name: main

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-awesome-pages-plugin==2.5.1
 mkdocs-macros-plugin==0.6.0
 requests==2.26.0
 mkdocs-minify-plugin==0.5.0
+mkdocs-exclude-search==0.6.4


### PR DESCRIPTION
The mkdocs-exclude-search plugin was installed (https://github.com/chrieke/mkdocs-exclude-search)

The following folders were excluded from the general search:
      exclude:
        - blog/*
        - events/*
        - staff/*
        - trufflecon2020/*