### PR TITLE
Add instructions for newly proposed "autocomplete" command

### DIFF
--- a/src/docs/truffle/reference/truffle-commands.md
+++ b/src/docs/truffle/reference/truffle-commands.md
@@ -19,6 +19,16 @@ Passing no arguments is equivalent to `truffle help`, which will display a list 
 
 ## Available commands
 
+### autocomplete
+
+Outputs completion settings to the console.
+
+```shell
+truffle autocomplete [bash|zsh]
+```
+
+The resulting output can be appended to `.bashrc` or `.zshrc` to enable command-line tab completion for each truffle command and sub-command. The bash and zsh shells are currently supported.
+
 ### build
 
 Execute build pipeline (if configuration present).


### PR DESCRIPTION
This PR covers the documentation for a [newly proposed "autocomplete" command](https://github.com/trufflesuite/truffle/pull/4761). 

This command outputs completion settings for either bash or zsh, which a user can append to their `.bashrc` or `.zshrc` scripts to enable tab completion in the command line. 

That PR is still open, so the two will need to be coordinated.