### PR TITLE
Remove unnecessary prefixes/suffixes on page titles

### DIFF
--- a/src/docs/filecoin/ganache/getting-started/get-started-with-nodejs.md
+++ b/src/docs/filecoin/ganache/getting-started/get-started-with-nodejs.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Filecoin-flavored NodeJS Library
+title: Filecoin-flavored NodeJS Library
 layout: docs.hbs
 ---
 # Get Started With using the Filecoin-flavored Ganache as a NodeJS Dependency

--- a/src/docs/filecoin/ganache/getting-started/get-started-with-the-cli.md
+++ b/src/docs/filecoin/ganache/getting-started/get-started-with-the-cli.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Filecoin-flavored CLI
+title: Filecoin-flavored CLI
 layout: docs.hbs
 ---
 # Get Started With using the Filecoin-flavored Ganache CLI

--- a/src/docs/filecoin/ganache/getting-started/get-started-with-the-gui.md
+++ b/src/docs/filecoin/ganache/getting-started/get-started-with-the-gui.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Filecoin-flavored GUI
+title: Filecoin-flavored GUI
 layout: docs.hbs
 ---
 # Get Started With using Filecoin-flavored Ganache GUI

--- a/src/docs/filecoin/ganache/overview.md
+++ b/src/docs/filecoin/ganache/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Working With Filecoin
+title: Working With Filecoin
 layout: docs.hbs
 ---
 # Working With Filecoin

--- a/src/docs/ganache/corda/cordapps.md
+++ b/src/docs/ganache/corda/cordapps.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Corda CorDapps
+title: Corda CorDapps
 layout: docs.hbs
 ---
 # CorDapps

--- a/src/docs/ganache/corda/linking-a-corda-project.md
+++ b/src/docs/ganache/corda/linking-a-corda-project.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Linking a CorDapp
+title: Linking a CorDapp
 layout: docs.hbs
 ---
 # Linking a CorDapp Project

--- a/src/docs/ganache/corda/nodes.md
+++ b/src/docs/ganache/corda/nodes.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Corda Nodes
+title: Corda Nodes
 layout: docs.hbs
 ---
 # Nodes

--- a/src/docs/ganache/corda/shell.md
+++ b/src/docs/ganache/corda/shell.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Corda Shell
+title: Corda Shell
 layout: docs.hbs
 ---
 # Shell

--- a/src/docs/ganache/corda/transactions.md
+++ b/src/docs/ganache/corda/transactions.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Corda Transactions
+title: Corda Transactions
 layout: docs.hbs
 ---
 # Transactions

--- a/src/docs/ganache/corda/unlinking-a-corda-project.md
+++ b/src/docs/ganache/corda/unlinking-a-corda-project.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Unlinking a Corda Project
+title: Unlinking a Corda Project
 layout: docs.hbs
 ---
 # Unlinking a Corda Project

--- a/src/docs/ganache/corda/working-with-corda.md
+++ b/src/docs/ganache/corda/working-with-corda.md
@@ -1,5 +1,5 @@
 ---
-title: XYZ
+title: Working with Corda
 layout: docs.hbs
 ---
 # Working With Corda

--- a/src/docs/ganache/corda/workspace-overview.md
+++ b/src/docs/ganache/corda/workspace-overview.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Corda Workspace Overview
+title: Corda Workspace Overview
 layout: docs.hbs
 ---
 # Corda Workspace Overview

--- a/src/docs/ganache/reference/ganache-settings.md
+++ b/src/docs/ganache/reference/ganache-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Ganache Settings
+title: Ganache Settings
 layout: docs.hbs
 ---
 

--- a/src/docs/ganache/reference/workspace-default-configuration.md
+++ b/src/docs/ganache/reference/workspace-default-configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Workspace Default Configuration
+title: Workspace Default Configuration
 layout: docs.hbs
 ---
 # Workspace Default Configuration

--- a/src/docs/ganache/truffle-projects/contracts-page.md
+++ b/src/docs/ganache/truffle-projects/contracts-page.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Contracts Page
+title: Contracts Page
 layout: docs.hbs
 ---
 # Contracts Page

--- a/src/docs/ganache/truffle-projects/decoded-transactions.md
+++ b/src/docs/ganache/truffle-projects/decoded-transactions.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Decoded Transactions
+title: Decoded Transactions
 layout: docs.hbs
 ---
 # Decoded Transactions

--- a/src/docs/ganache/truffle-projects/events-page.md
+++ b/src/docs/ganache/truffle-projects/events-page.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Events Page
+title: Events Page
 layout: docs.hbs
 ---
 # Events Page

--- a/src/docs/ganache/truffle-projects/linking-a-truffle-project.md
+++ b/src/docs/ganache/truffle-projects/linking-a-truffle-project.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Linking a Truffle Project
+title: Linking a Truffle Project
 layout: docs.hbs
 ---
 # Linking a Truffle Project

--- a/src/docs/ganache/truffle-projects/unlinking-a-truffle-project.md
+++ b/src/docs/ganache/truffle-projects/unlinking-a-truffle-project.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Unlinking a Truffle Project
+title: Unlinking a Truffle Project
 layout: docs.hbs
 ---
 # Unlinking a Truffle Project

--- a/src/docs/ganache/workspaces/creating-workspaces.md
+++ b/src/docs/ganache/workspaces/creating-workspaces.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Creating Workspaces
+title: Creating Workspaces
 layout: docs.hbs
 ---
 # Creating Workspaces

--- a/src/docs/ganache/workspaces/deleting-workspaces.md
+++ b/src/docs/ganache/workspaces/deleting-workspaces.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Deleting Workspaces
+title: Deleting Workspaces
 layout: docs.hbs
 ---
 # Deleting Workspaces

--- a/src/docs/ganache/workspaces/editing-workspaces.md
+++ b/src/docs/ganache/workspaces/editing-workspaces.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Editing Workspaces
+title: Editing Workspaces
 layout: docs.hbs
 ---
 # Editing Workspaces

--- a/src/docs/ganache/workspaces/ethereum-workspace-overview.md
+++ b/src/docs/ganache/workspaces/ethereum-workspace-overview.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Ethereum Workspace Overview
+title: Ethereum Workspace Overview
 layout: docs.hbs
 ---
 

--- a/src/docs/ganache/workspaces/loading-existing-workspaces.md
+++ b/src/docs/ganache/workspaces/loading-existing-workspaces.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Loading Existing Workspaces
+title: Loading Existing Workspaces
 layout: docs.hbs
 ---
 # Loading Existing Workspaces

--- a/src/docs/ganache/workspaces/switching-workspaces.md
+++ b/src/docs/ganache/workspaces/switching-workspaces.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | Switching Workspaces
+title: Switching Workspaces
 layout: docs.hbs
 ---
 # Switching Workspaces

--- a/src/docs/ganache/workspaces/the-quickstart-workspace.md
+++ b/src/docs/ganache/workspaces/the-quickstart-workspace.md
@@ -1,5 +1,5 @@
 ---
-title: Ganache | The Quickstart Workspace
+title: The Quickstart Workspace
 layout: docs.hbs
 ---
 # The Quickstart Workspace

--- a/src/docs/tezos/truffle/getting-started/compiling-tezos-contracts.md
+++ b/src/docs/tezos/truffle/getting-started/compiling-tezos-contracts.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Compiling LIGO contracts | Tezos
+title: Compiling LIGO contracts
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/getting-started/creating-a-tezos-project.md
+++ b/src/docs/tezos/truffle/getting-started/creating-a-tezos-project.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Creating a Tezos Project | Tezos
+title: Creating a Tezos Project
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/getting-started/deploying-tezos-contracts.md
+++ b/src/docs/tezos/truffle/getting-started/deploying-tezos-contracts.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Deploying Tezos Contracts
+title: Deploying Tezos Contracts
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/getting-started/installing-truffle-with-tezos.md
+++ b/src/docs/tezos/truffle/getting-started/installing-truffle-with-tezos.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Installation | Tezos
+title: Installation
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/getting-started/interacting-with-your-tezos-contracts.md
+++ b/src/docs/tezos/truffle/getting-started/interacting-with-your-tezos-contracts.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Interacting with Your Contracts
+title: Interacting with Your Contracts
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/getting-started/testing-your-tezos-contracts.md
+++ b/src/docs/tezos/truffle/getting-started/testing-your-tezos-contracts.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Testing Your Tezos Contracts
+title: Testing Your Tezos Contracts
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/getting-started/using-the-console-with-tezos.md
+++ b/src/docs/tezos/truffle/getting-started/using-the-console-with-tezos.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Using Truffle Console | Tezos
+title: Using Truffle Console
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/getting-started/writing-external-scripts-with-tezos.md
+++ b/src/docs/tezos/truffle/getting-started/writing-external-scripts-with-tezos.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Writing External Scripts with Tezos
+title: Writing External Scripts with Tezos
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/getting-started/writing-tezos-contracts.md
+++ b/src/docs/tezos/truffle/getting-started/writing-tezos-contracts.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Writing Tezos Contracts | Tezos
+title: Writing Tezos Contracts
 layout: docs.hbs
 ---
 

--- a/src/docs/tezos/truffle/reference/configuring-tezos-projects.md
+++ b/src/docs/tezos/truffle/reference/configuring-tezos-projects.md
@@ -1,5 +1,5 @@
 ---
-title: Truffle | Configuring Your Project | Tezos
+title: Configuring Your Project
 layout: docs.hbs
 ---
 


### PR DESCRIPTION
Hey, remember #1175?  Turns out we have a bunch more pages with the same problem!  So, I went and did the same thing to all of them -- removing prefixes and suffixes where they exist, so that the menu will look sensible.

Also, one page had somehow ended up on the website with a placeholder title "XYZ" in place of a real title, so I put a real title on it.