### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # New trufflesuite.com
 
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/trufflesuite/trufflesuite.com/badge)](https://www.gitpoap.io/gh/trufflesuite/trufflesuite.com)
+
 A new version (as of **Q4 2021**) of the [trufflesuite.com](https://trufflesuite.com) site, built upon [mkdocs](https://www.mkdocs.org/) and the [material](https://squidfunk.github.io/mkdocs-material/) theme.
 
 The goals of this release have included the following:


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie