### PR TITLE
Add boxes BSC and Material-UI

### DIFF
--- a/src/boxes/data.json
+++ b/src/boxes/data.json
@@ -149,6 +149,11 @@
     "repoName": "scribble-exercise-1",
     "official": false
   },
+  { "userOrg": "rouftom",
+    "displayName": "react-material-ui",
+    "repoName": "truffle-react-material",
+    "official": false
+  },
   {
     "userOrg": "skalenetwork",
     "displayName": "skale-box",

--- a/src/boxes/data.json
+++ b/src/boxes/data.json
@@ -319,6 +319,12 @@
     "official": false
   },
   {
+    "userOrg": "RumeelHussainbnb",
+    "displayName": "BSC-Truffle-Starter-Box",
+    "repoName": "BSC-Truffle-Starter-Box",
+    "official": false
+  },
+  {
     "userOrg": "hexeight",
     "displayName": "rapid-box",
     "repoName": "rapid-box",

--- a/src/data/boxes.json
+++ b/src/data/boxes.json
@@ -31,7 +31,7 @@
 		]
 	},
 	"truffle-react-material": {
-		"description": "This box contains everything you need to get started using smart contracts from a Rect app with the Material-ui library.",
+		"description": "This box contains everything you need to get started using smart contracts from a React app with the Material-ui library.",
 		"stars": 49,
 		"tags": [
 			"community",

--- a/src/data/boxes.json
+++ b/src/data/boxes.json
@@ -30,6 +30,15 @@
 			"community"
 		]
 	},
+	"truffle-react-material": {
+		"description": "This box contains everything you need to get started using smart contracts from a Rect app with the Material-ui library.",
+		"stars": 49,
+		"tags": [
+			"community",
+			"react",
+			"material-ui"
+		]
+	},
 	"angulartruffledapp": {
 		"description": "This Trufflebox provides a base for Truffle Suite and Angular ÐAPP. and you can make transactions between accounts",
 		"stars": 0,

--- a/src/data/boxes.json
+++ b/src/data/boxes.json
@@ -14,6 +14,15 @@
 			"community"
 		]
 	},
+	"BSC-Truffle-Starter-Box": {
+		"description": "This Truffle BNB Smart Chain box provides you with the boilerplate structure necessary to start coding on the BNB Smart Chain.",
+		"stars": 0,
+		"tags": [
+			"community",
+			"binance",
+			"bsc"
+		]
+	},
 	"angular-truffle-box": {
 		"description": "Truffle Box for Angular is a quick-and-easy way to get your Dapp on the road with Truffle and Angular",
 		"stars": 49,


### PR DESCRIPTION
This PR adds the [BSC](https://github.com/RumeelHussainbnb/BSC-Truffle-Starter-Box) and [React-Material-UI](https://github.com/rouftom/truffle-react-material) boxes to the Truffle website as community boxes.