### PR TITLE
Remove Legacy Analytics UA

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,9 +17,6 @@ theme:
   language: en
 copyright: Copyright &copy; 2016 - 2022 ConsenSys Software Inc.
 extra:
-  analytics:
-    provider: google
-    property: UA-83874933-3
   generator: false
   social:
   - icon: fontawesome/brands/twitter


### PR DESCRIPTION
removing the legacy analytics UA integration to avoid duplicate analytics as GTM already has analytics UA integration