### PR TITLE
Putting redirect in place for ganache overview 404

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,4 +73,5 @@ plugins:
         'tutorial/index.md': 'guides/pet-shop/index.md'
         'tutorial/pet-shop/index.md': 'guides/pet-shop/index.md'          
         'tutorials/index.md': 'guides/pet-shop/index.md'
-        'tutorials/pet-shop/index.md': 'guides/pet-shop/index.md'          
+        'tutorials/pet-shop/index.md': 'guides/pet-shop/index.md'
+        'docs/ganache/overview/index.md': 'docs/ganache/index.md'

--- a/src/ganache/overview/index.md
+++ b/src/ganache/overview/index.md
@@ -1,0 +1,1 @@
+Redirect to /docs/ganache


### PR DESCRIPTION
Fixing 404 mentioned in #1299

Example of the redirect in action: https://bafybeicyzrohxmdp6osvdfyepoydobwdy5oktm45qspsqcgeg4einczsby.on.fleek.co/docs/ganache/overview