### PR TITLE
Removing newsletter signup from top-level docs page

### DIFF
--- a/custom_theme/docs.html
+++ b/custom_theme/docs.html
@@ -157,25 +157,6 @@
     </div>
   </div>
 
-  <div class="row justify-content-center text-center mt-4">
-    <div class="col">
-      <div class="bd-dark-cream pt-4 pb-4 pl-5 pr-5 hs-form-inline hs-form-docs">
-        <h3>SIGN UP FOR THE TRUFFLE MAILING LIST</h3>
-        <p>Sign up today to be a member of the Truffle mailing list. You'll be added to our low volume mailing list which we'll use to communicate future changes, development ideas and allow you to shape Truffle's development.</p>
-        <!--[if lte IE 8]>
-          <script charset="utf-8" type="text/javascript" src="/js.hsforms.net/forms/v2-legacy.js"></script>
-        <![endif]-->
-        <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
-        <script>
-          hbspt.forms.create({
-            portalId: "4795067",
-            formId: "d18995c8-32bb-4b2d-bde9-3f49fb3d2837"
-          });
-        </script>
-      </div>
-    </div>
-  </div>
-
 </section>
 
 


### PR DESCRIPTION
The layout of the form (which comes from Hubspot) has changed since it moved to the page footer and as such it now looks pretty funky [at the bottom of the docs page](https://trufflesuite.com/docs/). Additionally, it doesn't feel like a particularly logical place to have it anyone.

<img width="1251" alt="Screen Shot 2022-10-06 at 11 49 11 AM" src="https://user-images.githubusercontent.com/210755/194372137-a128755c-03ff-41ef-81c1-642ff6e9e206.png">
