### PR TITLE
Remove hubspot

### DIFF
--- a/custom_theme/partials/footer.html
+++ b/custom_theme/partials/footer.html
@@ -64,11 +64,6 @@
   </div>
 </footer>
 
-<!-- Start of HubSpot Embed Code -->
-<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/4795067.js"></script>
-<!-- End of HubSpot Embed Code -->
-
-
 <script>
   (function () {
     // handle opening and closing of nav menus


### PR DESCRIPTION
Addresses: https://github.com/trufflesuite/trufflesuite.com/issues/1288

So I removed the script that brings in hubspot (which wasn't working btw) but assuming the class names prefixed with `hs-` are hubspot related, I didn't get rid of them because strangely some other parts of the website seem to rely on that styling? I left it in just so nothing else gets messed up.