### PR TITLE
Overriding incorrect h4 sizing rule

### DIFF
--- a/src/assets/stylesheets/extra.css
+++ b/src/assets/stylesheets/extra.css
@@ -348,6 +348,13 @@ a.link-card:hover {
 
 /* bootstrap overrides */
 
+.md-typeset h4 {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0em;
+  margin: 1em 0;
+}
+
 input:focus {
   /* an outline is required for accessibility */
   outline: solid 2px var(--mint);


### PR DESCRIPTION
# PR Description

This PR fixes an incorrect H4 `font-size` rule which sizes appropriately relative to the other headers. Before / after examples below...

<img width="260" alt="Screen Shot 2022-11-18 at 11 56 49 AM" src="https://user-images.githubusercontent.com/210755/202771586-f5727891-189d-4fa8-9d98-12e8b2e126c9.png">

<img width="202" alt="Screen Shot 2022-11-18 at 11 56 55 AM" src="https://user-images.githubusercontent.com/210755/202771424-44b142c0-2a8f-4e50-b5cf-54a59ec0edaa.png">

Example with the fix in place: https://bafybeiah4vuybb7tvc4undnrjncytayb5edub2mef3tdddcrplmkl2dlpe.on.fleek.co/docs/truffle/reference/configuration/#providers