### PR TITLE
Fixing 2x broken links on top-level truffle docs page

### DIFF
--- a/src/docs/truffle/index.md
+++ b/src/docs/truffle/index.md
@@ -12,9 +12,9 @@ layout: docs.hbs
 A world class development environment, testing framework and asset pipeline for blockchains using the Ethereum Virtual Machine (EVM), aiming to make life as a developer easier. With Truffle, you get:
 
 * Built-in smart contract compilation, linking, deployment and binary management.
-* [Advanced debugging](../how-to/debug-test/use-the-truffle-debugger.md) with breakpoints, variable analysis, and step functionality.
-* Use [console.log](https://trufflesuite.com/docs/truffle/reference/configuration/#soliditylog) in your smart contracts
-* Deployments and transactions through MetaMask with [Truffle Dashboard](../how-to/use-the-truffle-dashboard.md) to protect your mnemonic.
+* [Advanced debugging](/docs/truffle/how-to/debug-test/use-the-truffle-debugger) with breakpoints, variable analysis, and step functionality.
+* Use [console.log](/docs/truffle/reference/configuration/#soliditylog) in your smart contracts
+* Deployments and transactions through MetaMask with [Truffle Dashboard](/docs/truffle/how-to/use-the-truffle-dashboard) to protect your mnemonic.
 * External script runner that executes scripts within a Truffle environment.
 * Interactive console for direct contract communication.
 * Automated contract testing for rapid development.


### PR DESCRIPTION
Fixing up 2 broken links 🧐

[Deploy preview](https://bafybeiayclwmt2jt5ro6z7qb6tghwsr5mtnoixudwmw3dk5ztiwctlqhiy.on.fleek.co/docs/truffle/) (vs [current](https://trufflesuite.com/docs/truffle/)). Note it's the _Advanced debugging_ and _Truffle Dashboard_ links respectively. 