### PR TITLE
docs: fix typos

### DIFF
--- a/src/blog/the-infura-sdk-nft-truffle-box-all-you-need-to-know/index.md
+++ b/src/blog/the-infura-sdk-nft-truffle-box-all-you-need-to-know/index.md
@@ -60,7 +60,7 @@ Once these requirements are met, in an empty folder, run the unbox command as sh
 npx truffle unbox infura-nft-sdk
 ```
 
-This should download and unbox the Infura NFT SDK Box. Next download all project dependecies by running `npm install`.
+This should download and unbox the Infura NFT SDK Box. Next download all project dependencies by running `npm install`.
 
 With all dependencies successfully installed, proceed to creating a `.env` file in the root of your project, followed by adding values for the following environment variables:
 

--- a/src/docs/truffle/reference/contract-abstractions.md
+++ b/src/docs/truffle/reference/contract-abstractions.md
@@ -336,7 +336,7 @@ We recommend using this method of calling overloaded functions since it will una
 
 #### Processing transaction results
 
-When you make a transaction, you're given a `result` object that gives you a wealth of information about the transaction. You're given the transaction hash (`result.tx`), the decoded events (also known as logs; `result.logs`), and a transaction receipt (`result.receipt`). In the below example, you'll recieve the `ValueSet()` event because you triggered the event using the `setValue()` function:
+When you make a transaction, you're given a `result` object that gives you a wealth of information about the transaction. You're given the transaction hash (`result.tx`), the decoded events (also known as logs; `result.logs`), and a transaction receipt (`result.receipt`). In the below example, you'll receive the `ValueSet()` event because you triggered the event using the `setValue()` function:
 
 ```javascript
 const result = await instance.setValue(5);

--- a/src/guides/lens-protocol/index.md
+++ b/src/guides/lens-protocol/index.md
@@ -384,7 +384,7 @@ If you want to deploy to other networks, you can run:
 truffle migrate --network <NETWORK_NAME>
 ```
 
-Because there are so many contracts, compilation will take some time. Do note that every time you run the migration, it will overwrite what contract addreses have been written to `addresses.json`.
+Because there are so many contracts, compilation will take some time. Do note that every time you run the migration, it will overwrite what contract addresses have been written to `addresses.json`.
 
 ## Build your own module
 

--- a/src/guides/rentable-nft/index.md
+++ b/src/guides/rentable-nft/index.md
@@ -308,7 +308,7 @@ function _beforeTokenTransfer(
 }
 ```
 
-In order to delete the `UserInfo` from the mapping, we want to make sure there was actually a transfer of ownership and there was UserInfo on it in teh first place. Once verified, we can delete and emit an event that the UserInfo was updated!
+In order to delete the `UserInfo` from the mapping, we want to make sure there was actually a transfer of ownership and there was UserInfo on it in the first place. Once verified, we can delete and emit an event that the UserInfo was updated!
 
 Note that it is up to you, the contract writer, to decide if this is how you expect token transfers and burns to behave. You might choose to ignore this and say that rentees maintain their user status even when ownership changes!
 

--- a/src/guides/truffle-and-metamask/index.md
+++ b/src/guides/truffle-and-metamask/index.md
@@ -131,7 +131,7 @@ curl -d '{"jsonrpc":"2.0","method":"eth_sendTransaction","params": [{"from":"0x0
 ```
 
 ### Synchronizing Accounts Between Metamask And Testrpc
-If you want to use testrpc/Metamask combination for development purposes, another route to get the accounts in Metamask to be useful with testrpc is to use the HD wallet generation that both support. If you start testrpc it creates 10 different addresses that can be recovered by the supplied mnemonic. The ``testrpc` output show the 10 inital accounts, the 10 private keys for the accounts and the mnemonic to recreate those accounts.
+If you want to use testrpc/Metamask combination for development purposes, another route to get the accounts in Metamask to be useful with testrpc is to use the HD wallet generation that both support. If you start testrpc it creates 10 different addresses that can be recovered by the supplied mnemonic. The ``testrpc` output show the 10 initial accounts, the 10 private keys for the accounts and the mnemonic to recreate those accounts.
 
 ```
 Available Accounts


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `src/blog/crytic-continuous-assurance-for-smart-contracts/index.md`
1 typo in `src/blog/the-infura-sdk-nft-truffle-box-all-you-need-to-know/index.md`
1 typo in `src/docs/truffle/reference/contract-abstractions.md`
1 typo in `src/guides/lens-protocol/index.md`
1 typo in `src/guides/rentable-nft/index.md`
1 typo in `src/guides/truffle-and-metamask/index.md`


Best!